### PR TITLE
feat(theme): add dark theme support for components

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,0 +1,11 @@
+import { addons } from "@storybook/addons";
+
+addons.setConfig({
+  showPanel: true,
+  panelPosition: "right",
+  previewTabs: {
+    "storybook/docs/panel": {
+      hidden: true,
+    },
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# spartak-ui
-Spartak UI is a react component library
+# Spartak UI
+
+A React Components Library
+
+## Dark theme
+
+There are `ThemeProvider` and `useTheme` hook to add dark theme to your app. Wrap your app component into `ThemeProvider`.
+
+### Usage
+
+#### `ThemeProvider` wrapper
+
+```typescript
+import { ThemeProvider } from "spartak-ui";
+
+function Example() {
+  return (
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
+  );
+}
+```
+
+For switching themes let's add a component that utilizes `useTheme` hook.
+
+#### `Switch` component
+
+```typescript
+import { useTheme, Button } from "spartak-ui";
+import { IconSun, IconMoon } from "@tabler/icons-react";
+
+const Switch = () => {
+  const { theme, setTheme } = useTheme();
+  const isThemeDark = theme === "dark";
+  return (
+    <Button
+      onClick={
+        () => setTheme(
+        isThemeDark ?
+        "light" :
+        "dark")
+      }
+      icon={
+        isThemeDark ?
+        <IconSun /> :
+        <IconMoon />
+      }
+      variant="text"
+    />
+  );
+};
+```
+Import and add `Switch` component into your `<App />` and that's it.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A React Components Library
 
+## Components
+
+- [Button](https://github.com/shdq/spartak-ui/tree/main/components/button#button)
+
 ## Dark theme
 
 There are `ThemeProvider` and `useTheme` hook to add dark theme to your app. Wrap your app component into `ThemeProvider`.

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -40,26 +40,16 @@ const ButtonComponent = styled("button", {
       red: {
         $$color000: "$colors$red000",
         $$color100: "$colors$red100",
-        $$color200: "$colors$red200",
-        $$color300: "$colors$red300",
         $$color400: "$colors$red400",
         $$color500: "$colors$red500",
         $$color600: "$colors$red600",
-        $$color700: "$colors$red700",
-        $$color800: "$colors$red800",
-        $$color900: "$colors$red900",
       },
       blue: {
-        $$color100: "$colors$blue100",
         $$color000: "$colors$blue000",
-        $$color200: "$colors$blue200",
-        $$color300: "$colors$blue300",
+        $$color100: "$colors$blue100",
         $$color400: "$colors$blue400",
         $$color500: "$colors$blue500",
         $$color600: "$colors$blue600",
-        $$color700: "$colors$blue700",
-        $$color800: "$colors$blue800",
-        $$color900: "$colors$blue900",
       },
     },
 
@@ -76,7 +66,7 @@ const ButtonComponent = styled("button", {
         },
       },
       tinted: {
-        color: "$$color600",
+        color: "$$color400",
         backgroundColor: "$$color000",
         "&:hover": {
           backgroundColor: "$$color100",

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -93,9 +93,11 @@ const ButtonComponent = styled("button", {
         borderColor: "transparent",
         backgroundColor: "transparent",
         "&:hover": {
+          color: "$$color400",
           backgroundColor: "$$color000",
         },
         "&:disabled": {
+          color: "$$color600",
           backgroundColor: "transparent",
           opacity: 0.6,
         },

--- a/components/button/stories/Button.stories.tsx
+++ b/components/button/stories/Button.stories.tsx
@@ -1,6 +1,10 @@
+import { PropsWithChildren } from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { within, fireEvent } from "@storybook/testing-library";
 import { jest, expect } from "@storybook/jest";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
+import { Button } from "../Button";
 import {
   IconBell,
   IconExternalLink,
@@ -12,9 +16,6 @@ import {
   IconMoon,
 } from "@tabler/icons-react";
 
-import { Button } from "../Button";
-import { PropsWithChildren } from "react";
-
 const icons = {
   Empty: undefined,
   Email: <IconMail size={18} />,
@@ -25,6 +26,13 @@ const icons = {
 
 export default {
   title: "Components/Button",
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
   component: Button,
   argTypes: {
     variant: {

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,2 +1,3 @@
+export * from "./provider";
 export * from "./button";
 export * from "./input";

--- a/components/provider/ThemeProvider.tsx
+++ b/components/provider/ThemeProvider.tsx
@@ -1,0 +1,56 @@
+import {
+  useState,
+  useEffect,
+  createContext,
+  useContext,
+  PropsWithChildren,
+} from "react";
+import { theme as lightTheme, darkTheme, GlobalStyles } from "../stitches.config";
+
+type Theme = "light" | "dark";
+type ThemeContextType = {
+  theme: Theme;
+  setTheme: (theme: Theme, isSystemCall?: boolean) => void;
+};
+
+const themeClasses = {
+  light: lightTheme.className,
+  dark: darkTheme.className,
+};
+
+const ThemeContext = createContext<ThemeContextType | null>(null);
+
+export const ThemeProvider = ({ children }: PropsWithChildren) => {
+  const [themeMode, setThemeMode] = useState<Theme>("light");
+  const html = document.documentElement;
+
+  useEffect(() => {
+    const defaultTheme = localStorage["spartak-ui-theme"]
+      ? localStorage.getItem("spartak-ui-theme")
+      : window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+
+    if (themeMode !== defaultTheme) {
+      changeTheme(defaultTheme as Theme, true);
+    }
+
+    GlobalStyles();
+  }, []);
+
+  const changeTheme = (theme: Theme, isSystemCall = false) => {
+    html.classList.remove(themeClasses[themeMode]);
+    html.classList.add(themeClasses[theme]);
+    html.style.colorScheme = theme;
+    setThemeMode(theme);
+    if (!isSystemCall) localStorage.setItem("spartak-ui-theme", theme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme: themeMode, setTheme: changeTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext) as ThemeContextType;

--- a/components/provider/index.ts
+++ b/components/provider/index.ts
@@ -1,0 +1,3 @@
+import { ThemeProvider, useTheme } from "./ThemeProvider";
+
+export { useTheme, ThemeProvider };

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -51,13 +51,15 @@ const blueDark = {
   blue600: "#1F69FF",
 };
 
-export const { styled } = createStitches({
+export const { theme, styled, globalCss } = createStitches({
   theme: {
     colors: {
       ...red,
       ...blue,
       white: "#ffffff",
       focus: "#70C4E5",
+      background: "#ffffff",
+      foreground: "#222222",
     },
     space: {},
     fontSizes: {
@@ -88,5 +90,14 @@ export const darkTheme = createTheme({
   colors: {
     ...redDark,
     ...blueDark,
+    background: "#232425",
+    foreground: "#ffffff",
+  },
+});
+
+export const GlobalStyles = globalCss({
+  "body": {
+    backgroundColor: "$background",
+    color: "$foreground",
   },
 });

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -18,7 +18,7 @@ const redDark = {
   red000: "#490D0D",
   // tinted hover background
   red100: "#570F0F",
-  // text color for tinted
+  // text color for tinted and hovered text variant
   red400: "#E36464",
   // common primary color between light and dark
   red500: "#DE4D4D",
@@ -31,7 +31,7 @@ const blue = {
   blue000: "#EBF1FF",
   // tinted hover background
   blue100: "#C2D6FF",
-  // tinted text color
+  // tinted text color and hovered text variant
   blue400: "#0A5CFF",
   // common colors between light and dark
   blue500: "#3377FF",
@@ -43,7 +43,7 @@ const blueDark = {
   blue000: "#112B5F",
   // tinted hover background
   blue100: "#14326D",
-  // color for tinted
+  // color for tinted and hovered text variant
   blue400: "#5C92FF",
   // common primary color between light and dark
   blue500: "#3377FF",

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -1,32 +1,63 @@
-import { createStitches } from "@stitches/react";
+import { createStitches, createTheme } from "@stitches/react";
+
+const red = {
+  // tinted background
+  red000: "#FAE6E6",
+  // tinted hover background
+  red100: "#F6CCCC",
+  // tinted text color
+  red400: "#C72424",
+  // common primary color between light and dark
+  red500: "#DE4D4D",
+  // common hovered primary color between light and dark
+  red600: "#D93333",
+};
+
+const redDark = {
+  // tinted background
+  red000: "#490D0D",
+  // tinted hover background
+  red100: "#570F0F",
+  // text color for tinted
+  red400: "#E36464",
+  // common primary color between light and dark
+  red500: "#DE4D4D",
+  // common hovered primary color between light and dark
+  red600: "#D93333",
+};
+
+const blue = {
+  // tinted background
+  blue000: "#EBF1FF",
+  // tinted hover background
+  blue100: "#C2D6FF",
+  // tinted text color
+  blue400: "#0A5CFF",
+  // common colors between light and dark
+  blue500: "#3377FF",
+  blue600: "#1F69FF",
+};
+
+const blueDark = {
+  // tinted background
+  blue000: "#112B5F",
+  // tinted hover background
+  blue100: "#14326D",
+  // color for tinted
+  blue400: "#5C92FF",
+  // common primary color between light and dark
+  blue500: "#3377FF",
+  // common hovered primary color between light and dark
+  blue600: "#1F69FF",
+};
 
 export const { styled } = createStitches({
   theme: {
     colors: {
-      red000: "#FAE6E6",
-      red100: "#F6CCCC",
-      red200: "#EC9999",
-      red300: "#E88080",
-      red400: "#E36666",
-      red500: "#DE4D4D",
-      red600: "#D93333",
-      red700: "#D51A1A",
-      red800: "#D00000",
-      red900: "#BB0000",
-
-      blue000: "#EBF1FF",
-      blue100: "#C2D6FF",
-      blue200: "#99BBFF",
-      blue300: "#70A0FF",
-      blue400: "#4785FF",
-      blue500: "#1F69FF",
-      blue600: "#0052F5",
-      blue700: "#004FEB",
-      blue800: "#0044CC",
-      blue900: "#003DB8",
-
+      ...red,
+      ...blue,
       white: "#ffffff",
-      focus: "#70C4E5"
+      focus: "#70C4E5",
     },
     space: {},
     fontSizes: {
@@ -50,5 +81,12 @@ export const { styled } = createStitches({
     shadows: {},
     zIndices: {},
     transitions: {},
+  },
+});
+
+export const darkTheme = createTheme({
+  colors: {
+    ...redDark,
+    ...blueDark,
   },
 });


### PR DESCRIPTION
**Issue**: #7 

- Add a dark theme color palette, and adjust components for dark theme.
- Color palette is satisfying the WCAG contrast test.
- Introduced `ThemeProvider` context provider and `useTheme` hook to add theme support in client apps.
- Example of usage added to `README`
