### PR TITLE
feat(button): add sizes to button component

### DIFF
--- a/components/button/Button.test.tsx
+++ b/components/button/Button.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Button } from "./Button";
 import { IconSun } from "@tabler/icons-react";
+import { theme } from "../stitches.config";
 
 describe("Button", () => {
   test("should renders", () => {
@@ -40,6 +41,17 @@ describe("Button", () => {
     expect(onClickSpy).toHaveBeenCalled();
   });
 
+  test("should be disabled", () => {
+    // Arrange
+    render(<Button disabled>Button</Button>);
+
+    // Act
+    const button = screen.getByRole("button");
+
+    // Assert
+    expect(button).toBeDisabled();
+  });
+
   describe("with variant", () => {
     test("should renders with default variant when variant isn't present", () => {
       // Arrange
@@ -67,6 +79,40 @@ describe("Button", () => {
 
       // Assess
       expect(isClassPresent).toBe(true);
+    });
+  });
+
+  describe("with size", () => {
+    test("should renders with default size when size isn't present", () => {
+      // Arrange
+      render(<Button>Default size</Button>);
+
+      //Act
+      const button = screen.getByRole("button");
+      const isClassPresent = [...button.classList].some((className) =>
+        className.endsWith("size-sm")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
+
+    const themeSizes = theme.sizes;
+    Object.keys(themeSizes).map((size) => {
+      const label = themeSizes[size as keyof typeof themeSizes].token;
+
+      test(`should renders in ${label} size`, () => {
+        // Arrange
+        render(<Button size={label}>{label} size</Button>);
+
+        //Act
+        const button = screen.getByRole("button");
+
+        // Assess
+        expect(button).toHaveStyle(
+          `height: ${themeSizes[label]}, min-width: ${themeSizes[label]}`
+        );
+      });
     });
   });
 
@@ -181,18 +227,9 @@ describe("Button", () => {
       expect(endIcon).toBeNull();
     });
   });
+});
 
-  test("should be disabled", () => {
-    // Arrange
-    render(<Button disabled>Button</Button>);
-
-    // Act
-    const button = screen.getByRole("button");
-
-    // Assert
-    expect(button).toBeDisabled();
-  });
-
+describe("as link", () => {
   test("should renders as link when href and as props are present", () => {
     // Arrange
     render(

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -7,15 +7,11 @@ const ButtonComponent = styled("button", {
   cursor: "pointer",
   textDecoration: "none",
   fontFamily: "$system",
-  fontSize: "$default",
   fontWeight: "$normal",
 
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
-
-  minWidth: "32px",
-  height: "32px",
 
   whiteSpace: "nowrap",
   transition: "200ms",
@@ -105,11 +101,38 @@ const ButtonComponent = styled("button", {
         },
       },
     },
+    size: {
+      xs: {
+        fontSize: "$xs",
+        minWidth: "$sizes$xs",
+        height: "$sizes$xs",
+        $$wrapperPadding: "13px",
+      },
+      sm: {
+        fontSize: "$sm",
+        minWidth: "$sizes$sm",
+        height: "$sizes$sm",
+        $$wrapperPadding: "16px",
+      },
+      md: {
+        fontSize: "$md",
+        minWidth: "$sizes$md",
+        height: "$sizes$md",
+        $$wrapperPadding: "20px",
+      },
+      lg: {
+        fontSize: "$lg",
+        minWidth: "$sizes$lg",
+        height: "$sizes$lg",
+        $$wrapperPadding: "24px",
+      },
+    },
   },
 
   defaultVariants: {
     variant: "filled",
     color: "red",
+    size: "sm",
   },
 });
 
@@ -127,8 +150,8 @@ export const Button = ({ icon, endIcon, children, ...props }: ButtonProps) => {
     alignItems: "center",
     justifyContent: "center",
     gap: 4,
-    paddingLeft: children ? "16px" : 0,
-    paddingRight: children ? "16px" : 0,
+    paddingLeft: children ? "$$wrapperPadding" : 0,
+    paddingRight: children ? "$$wrapperPadding" : 0,
   });
 
   // it's button when "as" and "href"

--- a/components/button/README.MD
+++ b/components/button/README.MD
@@ -52,6 +52,27 @@ function App() {
 }
 ```
 
+## Sizes
+
+There are four different sizes of `Button`:
+
+- `xs` – extra small sized button
+- `sm` (default) – small sized button
+- `md` – medium sized button
+- `lg` – large size button
+
+If you don't specify `size` prop, default size will be used.
+
+### Usage
+
+```typescript
+import { Button } from "spartak-ui";
+
+function App() {
+  return <Button size="lg">Large</Button>;
+}
+```
+
 ## Icons
 
 There are `icon` and `endIcon` properties to place icon before and after `Button` label.

--- a/components/button/stories/Button.stories.tsx
+++ b/components/button/stories/Button.stories.tsx
@@ -62,54 +62,52 @@ export default {
   },
 } as ComponentMeta<typeof Button>;
 
-const Template: ComponentStory<typeof Button> = ({children, ...args}) => (
+const Template: ComponentStory<typeof Button> = ({ children, ...args }) => (
   <Button {...args}>{children}</Button>
 );
 
-export const FilledButton = Template.bind({});
-FilledButton.args = {
-  children: "Filled",
-  variant: "filled",
+const Default = Template.bind({});
+
+Default.args = {
   color: "red",
   size: "sm",
   disabled: false,
+};
+
+export const FilledButton = Template.bind({});
+FilledButton.args = {
+  ...Default.args,
+  children: "Filled",
+  variant: "filled",
 };
 
 export const TintedButton = Template.bind({});
 TintedButton.args = {
+  ...Default.args,
   children: "Tinted",
   variant: "tinted",
-  color: "red",
-  size: "sm",
-  disabled: false,
 };
 
 export const OutlinedButton = Template.bind({});
 OutlinedButton.args = {
+  ...Default.args,
   children: "Outlined",
   variant: "outlined",
-  color: "red",
-  size: "sm",
-  disabled: false,
 };
 
 export const TextButton = Template.bind({});
 TextButton.args = {
+  ...Default.args,
   children: "Text",
   variant: "text",
-  color: "red",
-  size: "sm",
-  disabled: false,
 };
 
 export const IconButton = Template.bind({});
 IconButton.args = {
+  ...Default.args,
   children: "Notifications",
   icon: <IconBell size={18} />,
   variant: "filled",
-  color: "red",
-  size: "md",
-  disabled: false,
 };
 
 export const SquareIconButtons = (args: PropsWithChildren) => {
@@ -125,17 +123,15 @@ export const SquareIconButtons = (args: PropsWithChildren) => {
   );
 };
 SquareIconButtons.args = {
+  ...Default.args,
   variant: "tinted",
-  color: "red",
-  disabled: false,
 };
 
 export const LinkButton = Template.bind({});
 LinkButton.args = {
+  ...Default.args,
   children: "Open link",
   variant: "text",
-  color: "red",
-  disabled: false,
   endIcon: <IconExternalLink size={18} />,
   href: "https://example.com",
   as: "a",

--- a/components/button/stories/Button.stories.tsx
+++ b/components/button/stories/Button.stories.tsx
@@ -37,6 +37,10 @@ export default {
       options: ["filled", "tinted", "outlined", "text"],
       control: { type: "select" },
     },
+    size: {
+      options: ["xs", "sm", "md", "lg"],
+      control: { type: "radio" },
+    },
     color: {
       options: ["red", "blue"],
       control: { type: "radio" },
@@ -67,6 +71,7 @@ FilledButton.args = {
   children: "Filled",
   variant: "filled",
   color: "red",
+  size: "sm",
   disabled: false,
 };
 
@@ -75,6 +80,7 @@ TintedButton.args = {
   children: "Tinted",
   variant: "tinted",
   color: "red",
+  size: "sm",
   disabled: false,
 };
 
@@ -83,6 +89,7 @@ OutlinedButton.args = {
   children: "Outlined",
   variant: "outlined",
   color: "red",
+  size: "sm",
   disabled: false,
 };
 
@@ -91,6 +98,7 @@ TextButton.args = {
   children: "Text",
   variant: "text",
   color: "red",
+  size: "sm",
   disabled: false,
 };
 
@@ -100,6 +108,7 @@ IconButton.args = {
   icon: <IconBell size={18} />,
   variant: "filled",
   color: "red",
+  size: "md",
   disabled: false,
 };
 

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -63,7 +63,10 @@ export const { theme, styled, globalCss } = createStitches({
     },
     space: {},
     fontSizes: {
-      default: "14px",
+      xs: "12px",
+      sm: "14px",
+      md: "16px",
+      lg: "18px",
     },
     fonts: {
       system:
@@ -74,7 +77,12 @@ export const { theme, styled, globalCss } = createStitches({
     },
     lineHeights: {},
     letterSpacings: {},
-    sizes: {},
+    sizes: {
+      xs: "26px",
+      sm: "32px",
+      md: "40px",
+      lg: "48px",
+    },
     borderWidths: {},
     borderStyles: {},
     radii: {
@@ -96,7 +104,7 @@ export const darkTheme = createTheme({
 });
 
 export const GlobalStyles = globalCss({
-  "body": {
+  body: {
     backgroundColor: "$background",
     color: "$foreground",
   },


### PR DESCRIPTION
**Description of changes**

New sizes for `Button` introduced:
- `xs` – extra small sized button
- `sm` (default) – small sized button
- `md` – medium sized button
- `lg` – large size button

**Usage**

```typescript
import { Button } from "spartak-ui";

function App() {
  return <Button size="lg">Large</Button>;
}
```

- [x] I updated examples in docs.

Resolves #10 