### PR TITLE
fix(ci): fix workflow that deploys storybook on push to main

### DIFF
--- a/.github/workflows/deploy-storybook-gh-pages.yml
+++ b/.github/workflows/deploy-storybook-gh-pages.yml
@@ -2,7 +2,8 @@ name: Deploy Storybook to Pages
 
 on:
   push:
-    branches: [$default-branch]
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
**Description**

This is a quick fix for the problem: workflow with the `$defaul-branch` variable doesn't automatically run on push to `main`, only manual triggering works.

Part of the issue: #12.