### PR TITLE
feat(input): add `TextInput` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A React Components Library
 ## Components
 
 - [Button](https://github.com/shdq/spartak-ui/tree/main/components/button#button)
+- [Input](https://github.com/shdq/spartak-ui/tree/main/components/input#textinput)
 
 ## Examples built with Spartak UI
 

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -1,9 +1,0 @@
-const inputStyles: React.CSSProperties = {
-  border: "1px solid #cccccc",
-  padding: "5px",
-  borderRadius: "5px",
-};
-
-export const Input = ({ ...props }) => (
-  <input style={inputStyles} {...props}></input>
-);

--- a/components/input/README.md
+++ b/components/input/README.md
@@ -1,0 +1,197 @@
+# TextInput
+
+A React component, intended to get user input
+
+### Usage
+
+```typescript
+import { TextInput } from "spartak-ui";
+
+function App() {
+  return (
+    <TextInput
+      placeholder="Enter something"
+    />;
+  );
+}
+```
+
+## Variants
+
+There are two different styles of `TextInput`:
+
+- `filled` (default)
+- `outlined`
+
+If you don't specify `variant` prop, default variant will be used.
+
+### Usage
+
+```typescript
+import { TextInput } from "spartak-ui";
+
+function App() {
+  return (
+    <TextInput
+      variant="outlined"
+      placeholder="Outlined variant"
+    />;
+  );
+}
+```
+
+## Sizes
+
+There are four different sizes of `TextInput`:
+
+- `xs` – extra small
+- `sm` (default) – small
+- `md` – medium
+- `lg` – large
+
+If you don't specify `size` prop, default size will be used.
+
+### Usage
+
+```typescript
+import { TextInput } from "spartak-ui";
+
+function App() {
+  return (
+    <TextInput
+      size="lg"
+      placeholder="Outlined variant"
+    />;
+  );
+}
+```
+
+## Disabled
+
+You can disable `TextInput` by specifying `disabled` property.
+
+### Usage
+
+```typescript
+import { TextInput } from "spartak-ui";
+
+function App() {
+  return (
+    <TextInput
+      placeholder="Disabled input"
+      disabled
+    />;
+  );
+}
+```
+
+## Icons
+
+There are `icon` and `endIcon` properties to place icon at start or end of `TextInput`.
+
+**NB:** You can use both properties to add both icons to `TextInput`
+
+### Usage
+
+```typescript
+import { TextInput } from "spartak-ui";
+import { IconSearch, IconMicrophone } from "@tabler/icons-react";
+
+function App() {
+  return (
+    <TextInput
+      icon={<IconSearch size={18} />}
+      endIcon={<IconMicrophone size={18} />}
+      placeholder="Search"
+    />;
+  );
+}
+```
+
+## Label
+
+With `label` property `TextInput` renders with proper label. There is optional `required` property, which adds <sup>`*`</sup> to the `label`.
+
+**NB:** If you don't use `label` property, you should add `aria-label` to `TextInput` for accessibility purpose.
+
+### Usage
+
+```typescript
+import { TextInput } from "spartak-ui";
+
+function App() {
+  return (
+    <TextInput
+      type="password"
+      placeholder="Your password"
+      label="Password"
+      required
+    />;
+  );
+}
+```
+
+## Description
+
+`description` property renders as supporting text under the `TextInput`.
+
+### Usage
+
+```typescript
+import { TextInput } from "spartak-ui";
+
+function App() {
+  return (
+    <TextInput
+      type="password"
+      placeholder="Your password"
+      description="Use 8 characters or more for your password"
+    />;
+  );
+}
+```
+
+## Error
+
+When you validate you form input, you can provide `error` property to add error message to the `TextInput`. It will highlight the input and replace description text with the error message.
+
+### Usage
+
+```typescript
+import { TextInput } from "spartak-ui";
+
+function App() {
+  return (
+    <TextInput
+      type="password"
+      placeholder="Your password"
+      description="Use 8 characters or more for your password"
+      error="Password is less than 8 characters"
+    />;
+  );
+}
+```
+
+## Controlled
+
+An example of controlled `TextInput` below.
+
+```typescript
+import { TextInput } from "spartak-ui";
+
+function App() {
+const [value, setValue] = React.useState('')
+  const handleChange = (event) => setValue(event.target.value)
+
+  return (
+    <>
+      <Text mb='8px'>Value: {value}</Text>
+      <Input
+        value={value}
+        onChange={handleChange}
+        placeholder='Here is a sample placeholder'
+        size='sm'
+      />
+    </>
+  )
+```

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import { TextInput } from "./TextInput";
+import { theme } from "../stitches.config";
 
 describe("TextInput", () => {
   test("should renders", () => {
@@ -43,5 +44,43 @@ describe("TextInput", () => {
 
     // Assert
     expect(input).toBeDisabled();
+  });
+
+  describe("with size", () => {
+    test("should renders with default size when size isn't present", () => {
+      // Arrange
+      render(<TextInput />);
+
+      //Act
+      const input = screen.getByRole("textbox");
+      const isClassPresent = [...input.classList].some((className) =>
+        className.endsWith("size-sm")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
+
+    const themeSizes = theme.sizes;
+    const themeSpaces = theme.space;
+    Object.keys(themeSizes).map((size) => {
+      const label = themeSizes[size as keyof typeof themeSizes].token;
+      const paddingLabel =
+        themeSpaces[`padding${label.toUpperCase()}` as keyof typeof themeSpaces]
+          .token;
+
+      test(`should renders in ${label} size`, () => {
+        // Arrange
+        render(<TextInput size={label} />);
+
+        //Act
+        const input = screen.getByRole("textbox");
+
+        // Assess
+        expect(input).toHaveStyle(
+          `height: ${themeSizes[label]}, padding: 0 ${themeSpaces[paddingLabel]}`
+        );
+      });
+    });
   });
 });

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TextInput } from "./TextInput";
 import { theme } from "../stitches.config";
+import { IconSearch, IconMicrophone } from "@tabler/icons-react";
 
 describe("TextInput", () => {
   test("should renders", () => {
@@ -241,6 +242,48 @@ describe("TextInput", () => {
           `height: ${themeSizes[label]}, padding: 0 ${themeSpaces[paddingLabel]}`
         );
       });
+    });
+  });
+
+  describe("with icon", () => {
+    test("should renders with icon", () => {
+      // Arrange
+      render(<TextInput icon={<IconSearch data-testid="svg-icon" />} />);
+
+      // Act
+      const icon = screen.getByTestId("svg-icon");
+
+      // Assert
+      expect(icon).toBeInTheDocument();
+    });
+
+    test("should renders with icon in the end", () => {
+      // Arrange
+      render(
+        <TextInput endIcon={<IconMicrophone data-testid="svg-mic-icon" />} />
+      );
+
+      // Act
+      const endIcon = screen.getByTestId("svg-mic-icon");
+
+      // Assert
+      expect(endIcon).toBeInTheDocument();
+    });
+
+    test("should renders with icons on both sides", () => {
+      // Arrange
+      render(<TextInput icon={<IconSearch data-testid="svg-search-icon" />} />);
+      render(
+        <TextInput endIcon={<IconMicrophone data-testid="svg-mic-icon" />} />
+      );
+
+      // Act
+      const icon = screen.getByTestId("svg-search-icon");
+      const endIcon = screen.getByTestId("svg-mic-icon");
+
+      // Assert
+      expect(icon).toBeInTheDocument();
+      expect(endIcon).toBeInTheDocument();
     });
   });
 });

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -49,81 +49,6 @@ describe("TextInput", () => {
     expect(input).not.toHaveFocus();
   });
 
-  test("should have label associated with input", () => {
-    // Arrange
-    render(<TextInput label="My label" />);
-
-    // Act
-    const input = screen.getByRole("textbox");
-    const label = screen.getByText("My label");
-
-    // Assert
-    expect(label).toBeInTheDocument();
-    expect(label).toHaveAttribute("for");
-    expect(input).toHaveAttribute("id");
-    expect(input.getAttribute("id")).toEqual(label.getAttribute("for"));
-  });
-
-  test("should have required label", () => {
-    // Arrange
-    render(<TextInput label="My label" required />);
-
-    // Act
-    const label = screen.getByText("My label");
-    const asterisk = screen.getByText("*");
-
-    // Assert
-    expect(label).toBeInTheDocument();
-    expect(asterisk).toBeInTheDocument();
-  });
-
-  test("should have ignore required prop is label is not present", () => {
-    // Arrange
-    render(<TextInput required />);
-
-    // Act
-    const asterisk = screen.queryByText("*");
-
-    // Assert
-    expect(asterisk).toBeNull();
-  });
-
-  test("should have labels and inputs with unique for/id", () => {
-    // Arrange
-    render(
-      <>
-        <TextInput label="First label" />
-        <TextInput label="Second label" />
-      </>
-    );
-
-    // Act
-    const firstLabel = screen.getByText("First label");
-    const firstInput = screen.getByLabelText("First label");
-    const secondLabel = screen.getByText("Second label");
-    const secondInput = screen.getByLabelText("Second label");
-
-    // Assert
-    expect(firstInput.getAttribute("id")).toEqual(firstLabel.getAttribute("for"));
-    expect(secondInput.getAttribute("id")).toEqual(secondLabel.getAttribute("for"));
-    expect(firstLabel.getAttribute("for")).not.toEqual(secondLabel.getAttribute("for"));
-    expect(firstInput.getAttribute("id")).not.toEqual(secondInput.getAttribute("id"));
-  });
-
-  test("should be in focus after click on label", async () => {
-    // Arrange
-    const user = userEvent.setup();
-    render(<TextInput label="My label" />);
-
-    // Act
-    const label = screen.getByText("My label");
-    const input = screen.getByLabelText("My label");
-    await user.click(label);
-
-    // Assert
-    expect(input).toHaveFocus();
-  });
-
   test("should have a description", () => {
     // Arrange
     render(<TextInput description="My description" />);
@@ -133,6 +58,122 @@ describe("TextInput", () => {
 
     // Assert
     expect(description).toBeInTheDocument();
+  });
+
+  describe("with label", () => {
+    test("should have label associated with input", () => {
+      // Arrange
+      render(<TextInput label="My label" />);
+
+      // Act
+      const input = screen.getByRole("textbox");
+      const label = screen.getByText("My label");
+
+      // Assert
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveAttribute("for");
+      expect(input).toHaveAttribute("id");
+      expect(input.getAttribute("id")).toEqual(label.getAttribute("for"));
+    });
+
+    test("should have required label", () => {
+      // Arrange
+      render(<TextInput label="My label" required />);
+
+      // Act
+      const label = screen.getByText("My label");
+      const asterisk = screen.getByText("*");
+
+      // Assert
+      expect(label).toBeInTheDocument();
+      expect(asterisk).toBeInTheDocument();
+    });
+
+    test("should have ignore required prop is label is not present", () => {
+      // Arrange
+      render(<TextInput required />);
+
+      // Act
+      const asterisk = screen.queryByText("*");
+
+      // Assert
+      expect(asterisk).toBeNull();
+    });
+
+    test("should have labels and inputs with unique for/id", () => {
+      // Arrange
+      render(
+        <>
+          <TextInput label="First label" />
+          <TextInput label="Second label" />
+        </>
+      );
+
+      // Act
+      const firstLabel = screen.getByText("First label");
+      const firstInput = screen.getByLabelText("First label");
+      const secondLabel = screen.getByText("Second label");
+      const secondInput = screen.getByLabelText("Second label");
+
+      // Assert
+      expect(firstInput.getAttribute("id")).toEqual(
+        firstLabel.getAttribute("for")
+      );
+      expect(secondInput.getAttribute("id")).toEqual(
+        secondLabel.getAttribute("for")
+      );
+      expect(firstLabel.getAttribute("for")).not.toEqual(
+        secondLabel.getAttribute("for")
+      );
+      expect(firstInput.getAttribute("id")).not.toEqual(
+        secondInput.getAttribute("id")
+      );
+    });
+
+    test("should be in focus after click on label", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      render(<TextInput label="My label" />);
+
+      // Act
+      const label = screen.getByText("My label");
+      const input = screen.getByLabelText("My label");
+      await user.click(label);
+
+      // Assert
+      expect(input).toHaveFocus();
+    });
+  });
+
+  describe("with error", () => {
+    test("should be invalid with error message", () => {
+      // Arrange
+      render(<TextInput error="Invalid value" />);
+
+      // Act
+      const error = screen.getByText("Invalid value");
+      const input = screen.getByRole("textbox");
+      const isClassPresent = [...input.classList].some((className) =>
+        className.endsWith("isInvalid-true")
+      );
+
+      // Assess
+      expect(error).toBeInTheDocument();
+      expect(isClassPresent).toBe(true);
+    });
+
+    test("should show error not description", () => {
+      // Arrange
+      render(<TextInput description="My description" error="Invalid value" />);
+
+      // Act
+      const description = screen.queryByText("My description");
+      const error = screen.getByText("Invalid value");
+
+      // Assert
+      expect(error).toBeInTheDocument();
+      expect(description).toBeNull();
+    });
   });
 
   describe("with variant", () => {

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -41,9 +41,11 @@ describe("TextInput", () => {
 
     // Act
     const input = screen.getByRole("textbox");
+    input.focus();
 
     // Assert
     expect(input).toBeDisabled();
+    expect(input).not.toHaveFocus();
   });
 
   describe("with size", () => {

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -48,6 +48,21 @@ describe("TextInput", () => {
     expect(input).not.toHaveFocus();
   });
 
+  test("should have label associated with input", () => {
+    // Arrange
+    render(<TextInput label="My label" />);
+
+    // Act
+    const input = screen.getByRole("textbox");
+    const label = screen.getByText("My label");
+
+    // Assert
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveAttribute("for");
+    expect(input).toHaveAttribute("id");
+    expect(input.getAttribute("id")).toEqual(label.getAttribute("for"));
+  });
+
   describe("with variant", () => {
     test("should renders with default variant when variant isn't present", () => {
       // Arrange

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -10,4 +10,38 @@ describe("TextInput", () => {
     // Act & Assert
     expect(input).toBeInTheDocument();
   });
+
+  test("should have placeholder", () => {
+    // Arrange
+    render(<TextInput placeholder="My placeholder" />);
+    const input = screen.getByRole("textbox");
+
+    // Act & Assert
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("placeholder", "My placeholder");
+  });
+
+  test("should be focusable", () => {
+    // Arrange
+    render(<TextInput />);
+    const input = screen.getByRole("textbox");
+
+    // Act & Assert
+    input.focus();
+    expect(input).toHaveFocus();
+
+    input.blur();
+    expect(input).not.toHaveFocus();
+  });
+
+  test("should be disabled", () => {
+    // Arrange
+    render(<TextInput disabled />);
+
+    // Act
+    const input = screen.getByRole("textbox");
+
+    // Assert
+    expect(input).toBeDisabled();
+  });
 });

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -48,6 +48,36 @@ describe("TextInput", () => {
     expect(input).not.toHaveFocus();
   });
 
+  describe("with variant", () => {
+    test("should renders with default variant when variant isn't present", () => {
+      // Arrange
+      render(<TextInput />);
+
+      //Act
+      const input = screen.getByRole("textbox");
+      const isClassPresent = [...input.classList].some((className) =>
+        className.endsWith("variant-filled")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
+
+    test("should renders with provided variant", () => {
+      // Arrange
+      render(<TextInput variant="outlined" />);
+
+      //Act
+      const input = screen.getByRole("textbox");
+      const isClassPresent = [...input.classList].some((className) =>
+        className.endsWith("variant-outlined")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
+  });
+
   describe("with size", () => {
     test("should renders with default size when size isn't present", () => {
       // Arrange

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, within } from "@testing-library/react";
+import { TextInput } from "./TextInput";
+
+describe("TextInput", () => {
+  test("should renders", () => {
+    // Arrange
+    render(<TextInput />);
+    const input = screen.getByRole("textbox");
+
+    // Act & Assert
+    expect(input).toBeInTheDocument();
+  });
+});

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -63,6 +63,28 @@ describe("TextInput", () => {
     expect(input.getAttribute("id")).toEqual(label.getAttribute("for"));
   });
 
+  test("should have labels and inputs with unique for/id", () => {
+    // Arrange
+    render(
+      <>
+        <TextInput label="First label" />
+        <TextInput label="Second label" />
+      </>
+    );
+
+    // Act
+    const firstLabel = screen.getByText("First label");
+    const firstInput = screen.getByLabelText("First label");
+    const secondLabel = screen.getByText("Second label");
+    const secondInput = screen.getByLabelText("Second label");
+
+    // Assert
+    expect(firstInput.getAttribute("id")).toEqual(firstLabel.getAttribute("for"));
+    expect(secondInput.getAttribute("id")).toEqual(secondLabel.getAttribute("for"));
+    expect(firstLabel.getAttribute("for")).not.toEqual(secondLabel.getAttribute("for"));
+    expect(firstInput.getAttribute("id")).not.toEqual(secondInput.getAttribute("id"));
+  });
+
   describe("with variant", () => {
     test("should renders with default variant when variant isn't present", () => {
       // Arrange

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -63,6 +63,30 @@ describe("TextInput", () => {
     expect(input.getAttribute("id")).toEqual(label.getAttribute("for"));
   });
 
+  test("should have required label", () => {
+    // Arrange
+    render(<TextInput label="My label" required />);
+
+    // Act
+    const label = screen.getByText("My label");
+    const asterisk = screen.getByText("*");
+
+    // Assert
+    expect(label).toBeInTheDocument();
+    expect(asterisk).toBeInTheDocument();
+  });
+
+  test("should have ignore required prop is label is not present", () => {
+    // Arrange
+    render(<TextInput required />);
+
+    // Act
+    const asterisk = screen.queryByText("*");
+
+    // Assert
+    expect(asterisk).toBeNull();
+  });
+
   test("should have labels and inputs with unique for/id", () => {
     // Arrange
     render(
@@ -83,6 +107,17 @@ describe("TextInput", () => {
     expect(secondInput.getAttribute("id")).toEqual(secondLabel.getAttribute("for"));
     expect(firstLabel.getAttribute("for")).not.toEqual(secondLabel.getAttribute("for"));
     expect(firstInput.getAttribute("id")).not.toEqual(secondInput.getAttribute("id"));
+  });
+
+  test("should have a description", () => {
+    // Arrange
+    render(<TextInput description="My description" />);
+
+    // Act
+    const description = screen.getByText("My description");
+
+    // Assert
+    expect(description).toBeInTheDocument();
   });
 
   describe("with variant", () => {

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { TextInput } from "./TextInput";
 import { theme } from "../stitches.config";
 
@@ -107,6 +108,20 @@ describe("TextInput", () => {
     expect(secondInput.getAttribute("id")).toEqual(secondLabel.getAttribute("for"));
     expect(firstLabel.getAttribute("for")).not.toEqual(secondLabel.getAttribute("for"));
     expect(firstInput.getAttribute("id")).not.toEqual(secondInput.getAttribute("id"));
+  });
+
+  test("should be in focus after click on label", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    render(<TextInput label="My label" />);
+
+    // Act
+    const label = screen.getByText("My label");
+    const input = screen.getByLabelText("My label");
+    await user.click(label);
+
+    // Assert
+    expect(input).toHaveFocus();
   });
 
   test("should have a description", () => {

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -1,12 +1,60 @@
 import { styled } from "../stitches.config";
 
-const InputComponent = styled("input", {});
+const InputComponent = styled("input", {
+  all: "unset",
+  border: "1px solid transparent",
+  borderRadius: "$3",
+  fontFamily: "$system",
+  fontWeight: "$normal",
+  color: "$grey700",
+
+  "&::placeholder": {
+    color: "$grey500",
+    opacity: 0.7,
+  },
+  "&:focus-visible": {
+    backgroundColor: "transparent",
+    outline: "3px solid $focus",
+  },
+
+  variants: {
+    variant: {
+      filled: {
+        backgroundColor: "$grey000",
+      },
+    },
+    size: {
+      xs: {
+        fontSize: "$xs",
+        height: "$sizes$xs",
+        padding: "0 $paddingXS",
+      },
+      sm: {
+        fontSize: "$sm",
+        height: "$sizes$sm",
+        padding: "0 $paddingSM",
+      },
+      md: {
+        fontSize: "$md",
+        height: "$sizes$md",
+        padding: "0 $paddingMD",
+      },
+      lg: {
+        fontSize: "$lg",
+        height: "$sizes$lg",
+        padding: "0 $paddingLG",
+      },
+    },
+  },
+  defaultVariants: {
+    variant: "filled",
+    size: "sm",
+  },
+});
 
 export interface TextInputProps
   extends React.ComponentProps<typeof InputComponent> {}
 
 export const TextInput = (props: TextInputProps) => {
-  return (
-      <InputComponent {...props} />
-  );
+  return <InputComponent {...props} />;
 };

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -2,11 +2,15 @@ import { styled } from "../stitches.config";
 
 const InputComponent = styled("input", {
   all: "unset",
+  cursor: "text",
   border: "$borderWidths$1 solid transparent",
   borderRadius: "$3",
   fontFamily: "$system",
   fontWeight: "$normal",
+  textAlign: "left",
   color: "$grey700",
+  width: "100%",
+  boxSizing: "border-box",
 
   "&:disabled": {
     cursor: "not-allowed",

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -74,12 +74,63 @@ export interface TextInputProps
   required?: boolean;
 }
 
-const Wrapper = styled("div", {});
-const Label = styled("label", {});
-const Description = styled("span", {});
-const AsteriskContainer = styled("span", {});
+const Wrapper = styled("div", {
+  fontFamily: "$system",
+  fontWeight: "$normal",
+  textAlign: "left",
+  color: "$grey500",
+  variants: {
+    size: {
+      xs: {
+        fontSize: "$xs",
+      },
+      sm: {
+        fontSize: "$sm",
+      },
+      md: {
+        fontSize: "$md",
+      },
+      lg: {
+        fontSize: "$lg",
+      },
+    },
+  },
+  defaultVariants: {
+    size: "sm",
+  },
+});
+const Label = styled("label", {
+  display: "block",
+  marginBottom: "3px",
+  userSelect: "none",
+});
+const Description = styled("span", {
+  variants: {
+    size: {
+      xs: {
+        fontSize: "$xxs",
+      },
+      sm: {
+        fontSize: "$xs",
+      },
+      md: {
+        fontSize: "$sm",
+      },
+      lg: {
+        fontSize: "$md",
+      },
+    },
+  },
+  defaultVariants: {
+    size: "sm",
+  },
+});
+const AsteriskContainer = styled("span", {
+  color: "$red500",
+  userSelect: "none",
+});
 const Asterisk = () => {
-  return <AsteriskContainer>*</AsteriskContainer>;
+  return <AsteriskContainer>&nbsp;*</AsteriskContainer>;
 };
 
 export const TextInput = ({
@@ -87,19 +138,20 @@ export const TextInput = ({
   description,
   label,
   required,
+  size,
   ...props
 }: TextInputProps) => {
   const id = useId();
   return (
-    <Wrapper>
+    <Wrapper size={size}>
       {label && (
         <Label htmlFor={id}>
           {label}
           {required && <Asterisk />}
         </Label>
       )}
-      <InputComponent id={id} {...props} />
-      {description && <Description>{description}</Description>}
+      <InputComponent id={id} size={size} {...props} />
+      {description && <Description size={size}>{description}</Description>}
     </Wrapper>
   );
 };

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { styled } from "../stitches.config";
 
 const InputComponent = styled("input", {
@@ -67,8 +68,21 @@ const InputComponent = styled("input", {
 });
 
 export interface TextInputProps
-  extends React.ComponentProps<typeof InputComponent> {}
+  extends React.ComponentProps<typeof InputComponent> {
+  label?: string;
+}
 
-export const TextInput = (props: TextInputProps) => {
+export const TextInput = ({ label, children, ...props }: TextInputProps) => {
+  const Wrapper = styled("div", {});
+  const Label = styled("label", {});
+  if (label) {
+    const id = useId();
+    return (
+      <Wrapper>
+        <Label htmlFor={id}>{label}</Label>
+        <InputComponent id={id} {...props} />
+      </Wrapper>
+    );
+  }
   return <InputComponent {...props} />;
 };

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -70,19 +70,36 @@ const InputComponent = styled("input", {
 export interface TextInputProps
   extends React.ComponentProps<typeof InputComponent> {
   label?: string;
+  description?: string;
+  required?: boolean;
 }
 
-export const TextInput = ({ label, children, ...props }: TextInputProps) => {
-  const Wrapper = styled("div", {});
-  const Label = styled("label", {});
-  if (label) {
-    const id = useId();
-    return (
-      <Wrapper>
-        <Label htmlFor={id}>{label}</Label>
-        <InputComponent id={id} {...props} />
-      </Wrapper>
-    );
-  }
-  return <InputComponent {...props} />;
+const Wrapper = styled("div", {});
+const Label = styled("label", {});
+const Description = styled("span", {});
+const AsteriskContainer = styled("span", {});
+const Asterisk = () => {
+  return <AsteriskContainer>*</AsteriskContainer>;
+};
+
+export const TextInput = ({
+  children,
+  description,
+  label,
+  required,
+  ...props
+}: TextInputProps) => {
+  const id = useId();
+  return (
+    <Wrapper>
+      {label && (
+        <Label htmlFor={id}>
+          {label}
+          {required && <Asterisk />}
+        </Label>
+      )}
+      <InputComponent id={id} {...props} />
+      {description && <Description>{description}</Description>}
+    </Wrapper>
+  );
 };

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -2,7 +2,7 @@ import { styled } from "../stitches.config";
 
 const InputComponent = styled("input", {
   all: "unset",
-  border: "1px solid transparent",
+  border: "$borderWidths$1 solid transparent",
   borderRadius: "$3",
   fontFamily: "$system",
   fontWeight: "$normal",
@@ -17,13 +17,20 @@ const InputComponent = styled("input", {
     opacity: 0.6,
   },
   "&:focus-visible": {
-    borderColor: "$grey400",
+    borderColor: "$focus",
   },
 
   variants: {
     variant: {
       filled: {
         backgroundColor: "$grey000",
+      },
+      outlined: {
+        backgroundColor: "transparent",
+        borderColor: "$grey500",
+        "&:focus-visible": {
+          borderColor: "$focus",
+        },
       },
     },
     size: {

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -68,7 +68,40 @@ const InputComponent = styled("input", {
         },
       },
     },
+    withIcon: {
+      true: {},
+    },
   },
+  compoundVariants: [
+    {
+      withIcon: true,
+      size: "xs",
+      css: {
+        paddingLeft: "$sizes$xs",
+      },
+    },
+    {
+      withIcon: true,
+      size: "sm",
+      css: {
+        paddingLeft: "$sizes$sm",
+      },
+    },
+    {
+      withIcon: true,
+      size: "md",
+      css: {
+        paddingLeft: "$sizes$md",
+      },
+    },
+    {
+      withIcon: true,
+      size: "lg",
+      css: {
+        paddingLeft: "$sizes$lg",
+      },
+    },
+  ],
   defaultVariants: {
     variant: "filled",
     size: "sm",
@@ -76,6 +109,7 @@ const InputComponent = styled("input", {
 });
 
 const InputWrapper = styled("div", {
+  position: "relative",
   fontFamily: "$system",
   fontWeight: "$normal",
   textAlign: "left",
@@ -142,10 +176,56 @@ const Asterisk = () => {
   return <AsteriskContainer>&nbsp;*</AsteriskContainer>;
 };
 
+const IconWrapper = styled("div", {
+  position: "absolute",
+  top: 0,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  zIndex: "1",
+  color: "$grey500",
+  pointerEvents: "none",
+
+  variants: {
+    position: {
+      start: {
+        left: 0,
+      },
+      end: {
+        right: 0,
+      },
+    },
+    size: {
+      xs: {
+        height: "$sizes$xs",
+        width: "$sizes$xs",
+      },
+      sm: {
+        height: "$sizes$sm",
+        width: "$sizes$sm",
+      },
+      md: {
+        height: "$sizes$md",
+        width: "$sizes$md",
+      },
+      lg: {
+        height: "$sizes$lg",
+        width: "$sizes$lg",
+      },
+    },
+  },
+  defaultVariants: {
+    position: "start",
+    size: "sm",
+  },
+});
+
 export interface TextInputProps
   extends React.ComponentProps<typeof InputComponent> {
   description?: string;
   error?: string;
+  endIcon?: React.ReactNode;
+  icon?: React.ReactNode;
   label?: string;
   required?: boolean;
 }
@@ -154,6 +234,8 @@ export const TextInput = ({
   children,
   description,
   error,
+  endIcon,
+  icon,
   label,
   required,
   size,
@@ -161,6 +243,7 @@ export const TextInput = ({
 }: TextInputProps) => {
   const id = useId();
   const isInvalid = !!error; // if error change border color
+  const withIcon = !!icon; // change left padding to icon container size
   return (
     <InputWrapper size={size}>
       {label && (
@@ -169,7 +252,24 @@ export const TextInput = ({
           {required && <Asterisk />}
         </Label>
       )}
-      <InputComponent isInvalid={isInvalid} id={id} size={size} {...props} />
+      {icon && (
+        <IconWrapper position="start" size={size}>
+          {icon}
+        </IconWrapper>
+      )}
+      <InputComponent
+        withIcon={withIcon}
+        isInvalid={isInvalid}
+        aria-invalid={isInvalid}
+        id={id}
+        size={size}
+        {...props}
+      />
+      {endIcon && (
+        <IconWrapper position="end" size={size}>
+          {endIcon}
+        </IconWrapper>
+      )}
       {(description || error) && (
         <SupportingText variant={error ? "error" : "description"} size={size}>
           {error ? error : description}

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -60,6 +60,14 @@ const InputComponent = styled("input", {
         padding: "0 $paddingLG",
       },
     },
+    isInvalid: {
+      true: {
+        borderColor: "$red500 !important",
+        "&:focus-visible": {
+          borderColor: "$focus !important",
+        },
+      },
+    },
   },
   defaultVariants: {
     variant: "filled",
@@ -67,14 +75,7 @@ const InputComponent = styled("input", {
   },
 });
 
-export interface TextInputProps
-  extends React.ComponentProps<typeof InputComponent> {
-  label?: string;
-  description?: string;
-  required?: boolean;
-}
-
-const Wrapper = styled("div", {
+const InputWrapper = styled("div", {
   fontFamily: "$system",
   fontWeight: "$normal",
   textAlign: "left",
@@ -104,9 +105,16 @@ const Label = styled("label", {
   marginBottom: "3px",
   userSelect: "none",
 });
-const Description = styled("span", {
-  color: "$grey500",
+const SupportingText = styled("span", {
   variants: {
+    variant: {
+      error: {
+        color: "$red500",
+      },
+      description: {
+        color: "$grey500",
+      },
+    },
     size: {
       xs: {
         fontSize: "$xxs",
@@ -134,25 +142,39 @@ const Asterisk = () => {
   return <AsteriskContainer>&nbsp;*</AsteriskContainer>;
 };
 
+export interface TextInputProps
+  extends React.ComponentProps<typeof InputComponent> {
+  description?: string;
+  error?: string;
+  label?: string;
+  required?: boolean;
+}
+
 export const TextInput = ({
   children,
   description,
+  error,
   label,
   required,
   size,
   ...props
 }: TextInputProps) => {
   const id = useId();
+  const isInvalid = !!error; // if error change border color
   return (
-    <Wrapper size={size}>
+    <InputWrapper size={size}>
       {label && (
         <Label htmlFor={id}>
           {label}
           {required && <Asterisk />}
         </Label>
       )}
-      <InputComponent id={id} size={size} {...props} />
-      {description && <Description size={size}>{description}</Description>}
-    </Wrapper>
+      <InputComponent isInvalid={isInvalid} id={id} size={size} {...props} />
+      {(description || error) && (
+        <SupportingText variant={error ? "error" : "description"} size={size}>
+          {error ? error : description}
+        </SupportingText>
+      )}
+    </InputWrapper>
   );
 };

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -8,13 +8,16 @@ const InputComponent = styled("input", {
   fontWeight: "$normal",
   color: "$grey700",
 
+  "&:disabled": {
+    cursor: "not-allowed",
+    opacity: 0.6,
+  },
   "&::placeholder": {
     color: "$grey500",
-    opacity: 0.7,
+    opacity: 0.6,
   },
   "&:focus-visible": {
-    backgroundColor: "transparent",
-    outline: "3px solid $focus",
+    borderColor: "$grey400",
   },
 
   variants: {

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -1,0 +1,12 @@
+import { styled } from "../stitches.config";
+
+const InputComponent = styled("input", {});
+
+export interface TextInputProps
+  extends React.ComponentProps<typeof InputComponent> {}
+
+export const TextInput = (props: TextInputProps) => {
+  return (
+      <InputComponent {...props} />
+  );
+};

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -78,7 +78,7 @@ const Wrapper = styled("div", {
   fontFamily: "$system",
   fontWeight: "$normal",
   textAlign: "left",
-  color: "$grey500",
+  color: "$grey700",
   variants: {
     size: {
       xs: {
@@ -105,6 +105,7 @@ const Label = styled("label", {
   userSelect: "none",
 });
 const Description = styled("span", {
+  color: "$grey500",
   variants: {
     size: {
       xs: {

--- a/components/input/index.ts
+++ b/components/input/index.ts
@@ -1,3 +1,3 @@
-import { Input } from "./Input";
+import { TextInput } from "./TextInput";
 
-export { Input };
+export { TextInput };

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -15,6 +15,10 @@ export default {
     ),
   ],
   argTypes: {
+    variant: {
+      options: ["filled", "outlined"],
+      control: { type: "select" },
+    },
     size: {
       options: ["xs", "sm", "md", "lg"],
       control: { type: "radio" },
@@ -76,9 +80,10 @@ WithDescription.args = {
   description: "Enter username or email",
 };
 
-export const WithLabelAndDescription = Template.bind({});
-WithLabelAndDescription.args = {
+export const RequiredLabelAndDescription = Template.bind({});
+RequiredLabelAndDescription.args = {
   ...Default.args,
   label: "Login",
   description: "Enter username or email",
+  required: true,
 };

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -62,3 +62,23 @@ WithLabel.args = {
   ...Default.args,
   label: "Login",
 };
+
+export const WithRequiredLabel = Template.bind({});
+WithRequiredLabel.args = {
+  ...Default.args,
+  label: "Login",
+  required: true,
+};
+
+export const WithDescription = Template.bind({});
+WithDescription.args = {
+  ...Default.args,
+  description: "Enter username or email",
+};
+
+export const WithLabelAndDescription = Template.bind({});
+WithLabelAndDescription.args = {
+  ...Default.args,
+  label: "Login",
+  description: "Enter username or email",
+};

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { useDarkMode } from "storybook-dark-mode";
-
+import { IconSearch, IconMicrophone, IconEye } from "@tabler/icons-react";
 import { darkTheme } from "../../stitches.config";
 import { TextInput } from "../TextInput";
 
@@ -59,6 +59,29 @@ DisabledWithValue.args = {
   ...Default.args,
   disabled: true,
   value: "Disabled with value",
+};
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  ...Default.args,
+  icon: <IconSearch size={18} />,
+  placeholder: "Search"
+};
+
+export const WithEndIcon = Template.bind({});
+WithEndIcon.args = {
+  ...Default.args,
+  endIcon: <IconEye size={18} />,
+  placeholder: "Your password",
+  type: "password",
+};
+
+export const WithBothIcon = Template.bind({});
+WithBothIcon.args = {
+  ...Default.args,
+  icon: <IconSearch size={18} />,
+  endIcon: <IconMicrophone size={18} />,
+  placeholder: "Search"
 };
 
 export const WithLabel = Template.bind({});

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -70,20 +70,20 @@ WithLabel.args = {
 export const WithRequiredLabel = Template.bind({});
 WithRequiredLabel.args = {
   ...Default.args,
-  label: "Login",
+  label: "Label text",
   required: true,
 };
 
 export const WithDescription = Template.bind({});
 WithDescription.args = {
   ...Default.args,
-  description: "Enter username or email",
+  description: "Description text",
 };
 
 export const RequiredLabelAndDescription = Template.bind({});
 RequiredLabelAndDescription.args = {
   ...Default.args,
-  label: "Login",
-  description: "Enter username or email",
+  label: "Label text",
+  description: "Description text",
   required: true,
 };

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -44,6 +44,12 @@ Filled.args = {
   type: "text",
 };
 
+export const Outlined = Template.bind({});
+Outlined.args = {
+  ...Default.args,
+  variant: "outlined",
+};
+
 export const DisabledWithValue = Template.bind({});
 DisabledWithValue.args = {
   ...Default.args,

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -1,9 +1,6 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { useDarkMode } from "storybook-dark-mode";
 
-import { within, userEvent } from '@storybook/testing-library';
-import { expect } from '@storybook/jest';
-
 import { darkTheme } from "../../stitches.config";
 import { TextInput } from "../TextInput";
 
@@ -18,6 +15,10 @@ export default {
     ),
   ],
   argTypes: {
+    size: {
+      options: ["xs", "sm", "md", "lg"],
+      control: { type: "radio" },
+    },
     type: {
       options: ["text", "password"],
       control: { type: "radio" },
@@ -25,27 +26,27 @@ export default {
   },
 } as ComponentMeta<typeof TextInput>;
 
-const Template: ComponentStory<typeof TextInput> = (args) => <TextInput data-testid="input" {...args} />;
+const Template: ComponentStory<typeof TextInput> = (args) => (
+  <TextInput {...args} />
+);
 
-export const Empty = Template.bind({});
-Empty.args = {
-  type: "text",
+const Default = Template.bind({});
+Default.args = {
+  variant: "filled",
+  size: "sm",
   disabled: false,
+  placeholder: "Text input",
 };
 
-export const FilledInput = Template.bind({});
-Empty.args = {
+export const Filled = Template.bind({});
+Filled.args = {
+  ...Default.args,
   type: "text",
-  disabled: false,
 };
-FilledInput.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
 
-  // Simulate interactions with the component
-  await userEvent.type(canvas.getByTestId('input'), 'some value');
-
-  // Assert DOM structure
-  await expect(
-    canvas.getByTestId('input')
-  ).toBeInTheDocument();
+export const DisabledWithValue = Template.bind({});
+DisabledWithValue.args = {
+  ...Default.args,
+  disabled: true,
+  value: "Disabled with value",
 };

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -64,7 +64,7 @@ DisabledWithValue.args = {
 export const WithLabel = Template.bind({});
 WithLabel.args = {
   ...Default.args,
-  label: "Login",
+  label: "Label text",
 };
 
 export const WithRequiredLabel = Template.bind({});
@@ -80,10 +80,25 @@ WithDescription.args = {
   description: "Description text",
 };
 
+export const WithError = Template.bind({});
+WithError.args = {
+  ...Default.args,
+  error: "Error message",
+};
+
 export const RequiredLabelAndDescription = Template.bind({});
 RequiredLabelAndDescription.args = {
   ...Default.args,
   label: "Label text",
   description: "Description text",
+  required: true,
+};
+
+export const RequiredLabelWithErrorAndDescription = Template.bind({});
+RequiredLabelWithErrorAndDescription.args = {
+  ...Default.args,
+  label: "Label text",
+  description: "Description text",
+  error: "Error message",
   required: true,
 };

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -56,3 +56,9 @@ DisabledWithValue.args = {
   disabled: true,
   value: "Disabled with value",
 };
+
+export const WithLabel = Template.bind({});
+WithLabel.args = {
+  ...Default.args,
+  label: "Login",
+};

--- a/components/input/stories/TextInput.stories.tsx
+++ b/components/input/stories/TextInput.stories.tsx
@@ -1,22 +1,31 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
 
 import { within, userEvent } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 
-import { Input } from "../Input";
+import { darkTheme } from "../../stitches.config";
+import { TextInput } from "../TextInput";
 
 export default {
   title: "Components/Input",
-  component: Input,
+  component: TextInput,
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     type: {
       options: ["text", "password"],
       control: { type: "radio" },
     },
   },
-} as ComponentMeta<typeof Input>;
+} as ComponentMeta<typeof TextInput>;
 
-const Template: ComponentStory<typeof Input> = (args) => <Input data-testid="input" {...args} />;
+const Template: ComponentStory<typeof TextInput> = (args) => <TextInput data-testid="input" {...args} />;
 
 export const Empty = Template.bind({});
 Empty.args = {

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -1,5 +1,25 @@
 import { createStitches, createTheme } from "@stitches/react";
 
+const grey = {
+  grey000: "#ededed",
+  grey100: "#c7c7c7",
+  grey400: "#8f8f8f",
+  grey500: "#5c5c5c",
+  grey600: "#171717",
+  // text color
+  grey700: "#161616",
+};
+
+const greyDark = {
+  grey000: "#232323",
+  grey100: "#3e3e3e",
+  grey400: "#707070",
+  grey500: "#6f6f6f",
+  grey600: "#171717",
+  // text color
+  grey700: "#ededed",
+};
+
 const red = {
   // tinted background
   red000: "#FAE6E6",
@@ -56,6 +76,7 @@ export const { theme, styled, globalCss } = createStitches({
     colors: {
       ...red,
       ...blue,
+      ...grey,
       white: "#ffffff",
       focus: "#53B7DF",
       background: "#ffffff",
@@ -110,6 +131,7 @@ export const darkTheme = createTheme({
   colors: {
     ...redDark,
     ...blueDark,
+    ...greyDark,
     focus: "#70C4E5",
     background: "#232425",
     foreground: "#ffffff",

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -7,7 +7,7 @@ const grey = {
   grey500: "#5c5c5c",
   grey600: "#171717",
   // text color
-  grey700: "#161616",
+  grey700: "#333333",
 };
 
 const greyDark = {
@@ -17,7 +17,7 @@ const greyDark = {
   grey500: "#6f6f6f",
   grey600: "#171717",
   // text color
-  grey700: "#ededed",
+  grey700: "#ebebeb",
 };
 
 const red = {

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -8,7 +8,7 @@ const grey = {
 };
 
 const greyDark = {
-  grey000: "#232323",
+  grey000: "#3d3d3d",
   grey500: "#8f8f8f",
   // text color
   grey700: "#ebebeb",

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -87,6 +87,7 @@ export const { theme, styled, globalCss } = createStitches({
       paddingLG: '18px',
     },
     fontSizes: {
+      xxs: "10px",
       xs: "12px",
       sm: "14px",
       md: "16px",

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -2,20 +2,14 @@ import { createStitches, createTheme } from "@stitches/react";
 
 const grey = {
   grey000: "#ededed",
-  grey100: "#c7c7c7",
-  grey400: "#8f8f8f",
-  grey500: "#5c5c5c",
-  grey600: "#171717",
+  grey500: "#999999",
   // text color
   grey700: "#333333",
 };
 
 const greyDark = {
   grey000: "#232323",
-  grey100: "#3e3e3e",
-  grey400: "#707070",
-  grey500: "#6f6f6f",
-  grey600: "#171717",
+  grey500: "#8f8f8f",
   // text color
   grey700: "#ebebeb",
 };


### PR DESCRIPTION
**Description of changes**

`TextInput` allows users to enter text into a UI. They appear mostly in forms.

**`TextInput` API**

- `placeholder` (optional) to fill in background text in the input.
- `disabled` property to disable input
- `label` a `<label>` tag for input to caption the input, also for accessibility purposes. Implementation details: consider wrapping the input with `label` or used with `for` and `id` attributes. Clicking on `label` should focus the input.
- `required` to show `*` with the label text (prop naming should be reconsidered).
- `description` (optional) to describe the purpose of the input and also show error messages if the value is invalid.
- `error` text of error to fill the description place and highlight the input.
- `variant` – `filled`, `outlined` more to come in separate issues
- `size` –  there are `xs`, `sm`, `md`, `lg` sizes. It depends on this #10 
- `icon` and `endIcon` to add icons to the input. Implement a `show/hide` icon button for the password type of input.
---
- [x] I added corresponding unit tests for covering all the features
- [x] I updated docs with examples of `TextInput` usage.


Resolves #16 