### PR TITLE
feat(card) add `Card` component

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,10 @@
+import { themes } from "@storybook/theming";
+import { darkTheme } from "../components/stitches.config";
 export const parameters = {
+  darkMode: {
+    // Override the default dark theme background
+    dark: { ...themes.dark, appContentBg: darkTheme.colors.background.value },
+  },
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
     matchers: {
@@ -6,4 +12,4 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+};

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A React Components Library
 ## Components
 
 - [Button](https://github.com/shdq/spartak-ui/tree/main/components/button#button)
+- [Card](https://github.com/shdq/spartak-ui/tree/main/components/card#card)
 - [Input](https://github.com/shdq/spartak-ui/tree/main/components/input#textinput)
 
 ## Examples built with Spartak UI

--- a/components/button/README.MD
+++ b/components/button/README.MD
@@ -4,11 +4,13 @@ Polymorphic React component, use it as a button or a link.
 
 ### Usage
 
-```typescript
+```jsx
 import { Button } from "spartak-ui";
 
 function App() {
-  return <Button>Click me!</Button>;
+  return (
+    <Button>Click me!</Button>;
+  );
 }
 ```
 
@@ -25,11 +27,15 @@ If you don't specify `variant` prop, default variant will be used.
 
 ### Usage
 
-```typescript
+```jsx
 import { Button } from "spartak-ui";
 
 function App() {
-  return <Button variant="outlined">Outlined</Button>;
+  return (
+    <Button variant="outlined">
+      Outlined
+    </Button>;
+  );
 }
 ```
 
@@ -44,11 +50,15 @@ If you don't specify `color` prop, default variant will be used.
 
 ### Usage
 
-```typescript
+```jsx
 import { Button } from "spartak-ui";
 
 function App() {
-  return <Button color="blue">Blue</Button>;
+  return (
+    <Button color="blue">
+      Blue
+    </Button>;
+  );
 }
 ```
 
@@ -65,11 +75,15 @@ If you don't specify `size` prop, default size will be used.
 
 ### Usage
 
-```typescript
+```jsx
 import { Button } from "spartak-ui";
 
 function App() {
-  return <Button size="lg">Large</Button>;
+  return (
+    <Button size="lg">
+      Large
+    </Button>;
+  );
 }
 ```
 
@@ -81,23 +95,32 @@ There are `icon` and `endIcon` properties to place icon before and after `Button
 
 ### Usage
 
-```typescript
+```jsx
 import { Button } from "spartak-ui";
 import { IconBell } from "@tabler/icons-react";
 
 function App() {
-  return <Button icon={<IconBell size={18} />}>Notifications</Button>;
+  return (
+    <Button icon={<IconBell size={18}/>}>
+      Notifications
+    </Button>;
+  );
 }
 ```
 
 Button with `icon` property and without children renders and square button with icon.
 
-```typescript
+```jsx
 import { Button } from "spartak-ui";
 import { IconSun } from "@tabler/icons-react";
 
 function App() {
-  return <Button icon={<IconSun size={18} />} variant="tinted" />;
+  return (
+    <Button
+      icon={<IconSun size={18} />}
+      variant="tinted"
+    />;
+  );
 }
 ```
 
@@ -107,11 +130,13 @@ You can disable `Button` by specifying `disabled` property.
 
 ### Usage
 
-```typescript
+```jsx
 import { Button } from "spartak-ui";
 
 function App() {
-  return <Button disabled>Submit</Button>;
+  return (
+    <Button disabled>Submit</Button>;
+  );
 }
 ```
 
@@ -121,12 +146,16 @@ Provide HTML element name `a` to `as` property and `href` with path or URL to re
 
 ### Usage
 
-```typescript
+```jsx
 import { Button } from "spartak-ui";
 
 function App() {
   return (
-    <Button variant="text" as="a" href="https://example.com">
+    <Button
+      variant="text"
+      as="a"
+      href="https://example.com"
+    >
       This is a link
     </Button>
   );
@@ -139,7 +168,7 @@ You can combine variants. Example below will render blue tinted button.
 
 ### Usage
 
-```typescript
+```jsx
 <Button variant="tinted" color="blue">
   Combined style
 </Button>

--- a/components/button/index.ts
+++ b/components/button/index.ts
@@ -1,3 +1,1 @@
-import { Button } from "./Button";
-
-export { Button };
+export { Button } from "./Button";

--- a/components/card/Card.test.tsx
+++ b/components/card/Card.test.tsx
@@ -18,24 +18,31 @@ describe("Card", () => {
     expect(cardBody).toBeInTheDocument();
   });
 
-  describe("with size", () => {
-    test("should renders with default size when size isn't present", () => {
-      // Arrange
-      render(
-        <Card data-testid="card">
-          <CardBody>Default size</CardBody>
-        </Card>
-      );
-
-      //Act
-      const card = screen.getByTestId("card");
-      const isClassPresent = [...card.classList].some((className) =>
-        className.endsWith("size-sm")
-      );
-
-      // Assess
-      expect(isClassPresent).toBe(true);
+  test("should have header and footer with semantic tags", () => {
+    // Arrange
+    render(
+      <Card data-testid="card">
+        <CardHeader>Header</CardHeader>
+        <CardBody>Body</CardBody>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    );
+    const card = screen.getByTestId((testId, element) => {
+      return element?.tagName.toLowerCase() === "section" && testId === "card";
     });
+    const cardHeader = within(card).getByText((text, element) => {
+      return element?.tagName.toLowerCase() === "header" && text === "Header";
+    });
+    const cardBody = within(card).getByText("Body");
+    const cardFooter = within(card).getByText((text, element) => {
+      return element?.tagName.toLowerCase() === "footer" && text === "Footer";
+    });
+
+    // Act & Assert
+    expect(card).toBeInTheDocument();
+    expect(cardHeader).toBeInTheDocument();
+    expect(cardBody).toBeInTheDocument();
+    expect(cardFooter).toBeInTheDocument();
   });
 
   describe("with variant", () => {
@@ -51,6 +58,60 @@ describe("Card", () => {
       const card = screen.getByTestId("card");
       const isClassPresent = [...card.classList].some((className) =>
         className.endsWith("variant-filled")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
+
+    test("should renders as filled variant", () => {
+      // Arrange
+      render(
+        <Card data-testid="card" variant="filled">
+          <CardBody>Outlined variant</CardBody>
+        </Card>
+      );
+
+      //Act
+      const card = screen.getByTestId("card");
+      const isClassPresent = [...card.classList].some((className) =>
+        className.endsWith("variant-filled")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
+
+    test("should renders as outlined variant", () => {
+      // Arrange
+      render(
+        <Card data-testid="card" variant="outlined">
+          <CardBody>Outlined variant</CardBody>
+        </Card>
+      );
+
+      //Act
+      const card = screen.getByTestId("card");
+      const isClassPresent = [...card.classList].some((className) =>
+        className.endsWith("variant-outlined")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
+
+    test("should renders as elevated variant", () => {
+      // Arrange
+      render(
+        <Card data-testid="card" variant="elevated">
+          <CardBody>Elevated variant</CardBody>
+        </Card>
+      );
+
+      //Act
+      const card = screen.getByTestId("card");
+      const isClassPresent = [...card.classList].some((className) =>
+        className.endsWith("variant-elevated")
       );
 
       // Assess

--- a/components/card/Card.test.tsx
+++ b/components/card/Card.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, within } from "@testing-library/react";
+import { Card, CardHeader, CardBody, CardFooter } from "./Card";
+
+describe("Card", () => {
+  test("should renders", () => {
+    // Arrange
+    render(
+      <Card data-testid="card">
+        <CardBody>Basic card</CardBody>
+      </Card>
+    );
+    const card = screen.getByTestId("card");
+    const cardBody = within(card).getByText("Basic card");
+
+    // Act & Assert
+    expect(card).toBeInTheDocument();
+    expect(cardBody).toBeInTheDocument();
+  });
+});

--- a/components/card/Card.test.tsx
+++ b/components/card/Card.test.tsx
@@ -37,4 +37,24 @@ describe("Card", () => {
       expect(isClassPresent).toBe(true);
     });
   });
+
+  describe("with variant", () => {
+    test("should renders with default variant when variant isn't present", () => {
+      // Arrange
+      render(
+        <Card data-testid="card">
+          <CardBody>Default variant</CardBody>
+        </Card>
+      );
+
+      //Act
+      const card = screen.getByTestId("card");
+      const isClassPresent = [...card.classList].some((className) =>
+        className.endsWith("variant-filled")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
+  });
 });

--- a/components/card/Card.test.tsx
+++ b/components/card/Card.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import { Card, CardHeader, CardBody, CardFooter } from "./Card";
+import { theme } from "../stitches.config";
 
 describe("Card", () => {
   test("should renders", () => {
@@ -15,5 +16,25 @@ describe("Card", () => {
     // Act & Assert
     expect(card).toBeInTheDocument();
     expect(cardBody).toBeInTheDocument();
+  });
+
+  describe("with size", () => {
+    test("should renders with default size when size isn't present", () => {
+      // Arrange
+      render(
+        <Card data-testid="card">
+          <CardBody>Default size</CardBody>
+        </Card>
+      );
+
+      //Act
+      const card = screen.getByTestId("card");
+      const isClassPresent = [...card.classList].some((className) =>
+        className.endsWith("size-sm")
+      );
+
+      // Assess
+      expect(isClassPresent).toBe(true);
+    });
   });
 });

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -3,6 +3,7 @@ import { styled } from "../stitches.config";
 export const Card = styled("section", {
   fontFamily: "$system",
   fontWeight: "$normal",
+  color: "$foreground",
   border: "$borderWidths$1 solid transparent",
   boxSizing: "border-box",
   position: "relative",
@@ -10,7 +11,7 @@ export const Card = styled("section", {
   display: "flex",
   gap: "8px",
   flexDirection: "column",
-  padding: "16px",
+  padding: "$paddingMD",
 
   variants: {
     variant: {

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,8 +1,39 @@
 import { styled } from "../stitches.config";
 
 export const Card = styled("div", {
+  boxSizing: "border-box",
+  position: "relative",
+  borderRadius: "$3",
   display: "flex",
+  gap: "8px",
   flexDirection: "column",
+  padding: "16px",
+
+  variants: {
+    variant: {
+      filled: {
+        backgroundColor: "$grey400",
+      },
+    },
+    size: {
+      xs: {
+        minWidth: "240px",
+      },
+      sm: {
+        minWidth: "280px",
+      },
+      md: {
+        minWidth: "320px",
+      },
+      lg: {
+        minWidth: "360px",
+      },
+    },
+  },
+  defaultVariants: {
+    variant: "filled",
+    size: "sm",
+  },
 });
 export const CardHeader = styled("div", {});
 export const CardBody = styled("div", {

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,0 +1,11 @@
+import { styled } from "../stitches.config";
+
+export const Card = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+});
+export const CardHeader = styled("div", {});
+export const CardBody = styled("div", {
+  flex: "1 1 auto",
+});
+export const CardFooter = styled("div", {});

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,6 +1,6 @@
 import { styled } from "../stitches.config";
 
-export const Card = styled("div", {
+export const Card = styled("section", {
   fontFamily: "$system",
   fontWeight: "$normal",
   border: "$borderWidths$1 solid transparent",
@@ -26,28 +26,13 @@ export const Card = styled("div", {
         boxShadow: "$shadows$boxShadow",
       },
     },
-    size: {
-      xs: {
-        maxWidth: "240px",
-      },
-      sm: {
-        maxWidth: "280px",
-      },
-      md: {
-        maxWidth: "320px",
-      },
-      lg: {
-        maxWidth: "360px",
-      },
-    },
   },
   defaultVariants: {
     variant: "filled",
-    size: "sm",
   },
 });
-export const CardHeader = styled("div", {});
+export const CardHeader = styled("header", {});
 export const CardBody = styled("div", {
   flex: "1 1 auto",
 });
-export const CardFooter = styled("div", {});
+export const CardFooter = styled("footer", {});

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,6 +1,9 @@
 import { styled } from "../stitches.config";
 
 export const Card = styled("div", {
+  fontFamily: "$system",
+  fontWeight: "$normal",
+  border: "$borderWidths$1 solid transparent",
   boxSizing: "border-box",
   position: "relative",
   borderRadius: "$3",
@@ -12,21 +15,29 @@ export const Card = styled("div", {
   variants: {
     variant: {
       filled: {
-        backgroundColor: "$grey400",
+        backgroundColor: "$grey300",
+      },
+      outlined: {
+        backgroundColor: "transparent",
+        borderColor: "$grey400",
+      },
+      elevated: {
+        backgroundColor: "$grey300",
+        boxShadow: "$shadows$boxShadow",
       },
     },
     size: {
       xs: {
-        minWidth: "240px",
+        maxWidth: "240px",
       },
       sm: {
-        minWidth: "280px",
+        maxWidth: "280px",
       },
       md: {
-        minWidth: "320px",
+        maxWidth: "320px",
       },
       lg: {
-        minWidth: "360px",
+        maxWidth: "360px",
       },
     },
   },

--- a/components/card/README.md
+++ b/components/card/README.md
@@ -1,0 +1,73 @@
+# Card
+
+`Card` contains content on a single subject.
+
+It has `CardHeader`, `CardBody`, and `CardFooter` components to structure content inside card.
+
+### Usage
+
+```jsx
+import { Card, CardBody } from "spartak-ui";
+
+function App() {
+  return (
+    <Card>
+      <CardBody>
+        This is card
+      </CardBody>
+    </Card>
+  );
+}
+```
+
+## Variants
+
+There are three different styles of `Card`:
+
+- `filled` (default)
+- `outlined`
+- `elevated`
+
+If you don't specify `variant` prop, default variant will be used.
+
+### Usage
+
+```jsx
+import { Card, CardBody } from "spartak-ui";
+
+function App() {
+  return (
+    <Card variant="outlined">
+      <CardBody>
+        This is outlined card
+      </CardBody>
+    </Card>
+  );
+}
+```
+
+## Card with full structure
+
+`CardFooter` is stick to the bottom of `Card`.
+
+### Usage
+
+```jsx
+import { Card, CardHeader, CardBody, CardFooter } from from "spartak-ui";
+
+function App() {
+  return (
+    <Card>
+      <CardHeader>
+        <h2>Header</h2>
+      </CardHeader>
+      <CardBody>
+        <p>Body</p>
+      </CardBody>
+      <CardFooter>
+        <p>Footer</p>
+      </CardFooter>
+    </Card>
+  );
+}
+```

--- a/components/card/index.ts
+++ b/components/card/index.ts
@@ -1,0 +1,1 @@
+export { Card, CardHeader, CardBody, CardFooter } from "./Card";

--- a/components/card/stories/Card.stories.tsx
+++ b/components/card/stories/Card.stories.tsx
@@ -1,20 +1,23 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { ThemeProvider } from "../../index";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
 import { Card, CardHeader, CardBody, CardFooter } from "../Card";
-import { Switch } from "../../provider/Switch";
 
 export default {
   title: "Components/Card",
   component: Card,
   decorators: [
     (Story) => (
-      <ThemeProvider>
-        <Switch />
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
         <Story />
-      </ThemeProvider>
+      </div>
     ),
   ],
   argTypes: {
+    variant: {
+      options: ["filled", "outlined", "elevated"],
+      control: { type: "radio" },
+    },
     size: {
       options: ["xs", "sm", "md", "lg"],
       control: { type: "radio" },

--- a/components/card/stories/Card.stories.tsx
+++ b/components/card/stories/Card.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { useDarkMode } from "storybook-dark-mode";
 import { darkTheme } from "../../stitches.config";
+import { Button, TextInput } from "../../index";
 import { Card, CardHeader, CardBody, CardFooter } from "../Card";
 
 export default {
@@ -52,5 +53,50 @@ export const Elevated = Template.bind({});
 Elevated.args = {
   ...Default.args,
   children: <CardBody>Elevated card</CardBody>,
+  variant: "elevated",
+};
+
+const loginForm = (
+  <>
+    <CardHeader
+      css={{
+        textAlign: "center",
+        fontWeight: 600,
+        fontSize: "$lg",
+        color: "$grey700",
+        marginBottom: "8px",
+      }}
+    >
+      Log in
+    </CardHeader>
+    <CardBody css={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+      <TextInput
+        label="Email"
+        placeholder="Enter your email"
+        // description="e.g. name@example.com"
+      />
+      <TextInput
+        label="Password"
+        type="password"
+        placeholder="Enter your password"
+      />
+      <Button>Continue</Button>
+    </CardBody>
+    <CardFooter css={{ textAlign: "center" }}>
+      <Button
+        as="a"
+        href="https://example.com"
+        variant="text"
+      >
+        Forgot your password?
+      </Button>
+    </CardFooter>
+  </>
+);
+
+export const CardWithForm = Template.bind({});
+CardWithForm.args = {
+  ...Default.args,
+  children: loginForm,
   variant: "elevated",
 };

--- a/components/card/stories/Card.stories.tsx
+++ b/components/card/stories/Card.stories.tsx
@@ -1,26 +1,39 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useDarkMode } from "storybook-dark-mode";
-import { darkTheme } from "../../stitches.config";
+import { ThemeProvider } from "../../index";
 import { Card, CardHeader, CardBody, CardFooter } from "../Card";
+import { Switch } from "../../provider/Switch";
 
 export default {
   title: "Components/Card",
   component: Card,
   decorators: [
     (Story) => (
-      <div className={useDarkMode() ? darkTheme.className : undefined}>
-        <Story />
-      </div>
+      <ThemeProvider>
+        <Switch />
+        <div
+          style={{
+            width: "200px",
+          }}
+        >
+          <Story />
+        </div>
+      </ThemeProvider>
     ),
   ],
-  argTypes: {},
+  argTypes: {
+    size: {
+      options: ["xs", "sm", "md", "lg"],
+      control: { type: "radio" },
+    },
+  },
 } as ComponentMeta<typeof Card>;
 
 const Template: ComponentStory<typeof Card> = ({ children, ...args }) => (
   <Card {...args}>{children}</Card>
 );
 
-export const Basic = Template.bind({});
-Basic.args = {
-  children: <CardBody>Basic card</CardBody>,
+export const Filled = Template.bind({});
+Filled.args = {
+  children: <CardBody>Filled card</CardBody>,
+  size: "sm",
 };

--- a/components/card/stories/Card.stories.tsx
+++ b/components/card/stories/Card.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
+import { Card, CardHeader, CardBody, CardFooter } from "../Card";
+
+export default {
+  title: "Components/Card",
+  component: Card,
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {},
+} as ComponentMeta<typeof Card>;
+
+const Template: ComponentStory<typeof Card> = ({ children, ...args }) => (
+  <Card {...args}>{children}</Card>
+);
+
+export const Basic = Template.bind({});
+Basic.args = {
+  children: <CardBody>Basic card</CardBody>,
+};

--- a/components/card/stories/Card.stories.tsx
+++ b/components/card/stories/Card.stories.tsx
@@ -10,13 +10,7 @@ export default {
     (Story) => (
       <ThemeProvider>
         <Switch />
-        <div
-          style={{
-            width: "200px",
-          }}
-        >
-          <Story />
-        </div>
+        <Story />
       </ThemeProvider>
     ),
   ],
@@ -32,8 +26,28 @@ const Template: ComponentStory<typeof Card> = ({ children, ...args }) => (
   <Card {...args}>{children}</Card>
 );
 
+const Default = Template.bind({});
+Default.args = {
+  size: "sm",
+  variant: "filled",
+};
+
 export const Filled = Template.bind({});
 Filled.args = {
+  ...Default.args,
   children: <CardBody>Filled card</CardBody>,
-  size: "sm",
+};
+
+export const Outlined = Template.bind({});
+Outlined.args = {
+  ...Default.args,
+  children: <CardBody>Outlined card</CardBody>,
+  variant: "outlined",
+};
+
+export const Elevated = Template.bind({});
+Elevated.args = {
+  ...Default.args,
+  children: <CardBody>Elevated card</CardBody>,
+  variant: "elevated",
 };

--- a/components/card/stories/Card.stories.tsx
+++ b/components/card/stories/Card.stories.tsx
@@ -19,10 +19,6 @@ export default {
       options: ["filled", "outlined", "elevated"],
       control: { type: "radio" },
     },
-    size: {
-      options: ["xs", "sm", "md", "lg"],
-      control: { type: "radio" },
-    },
   },
 } as ComponentMeta<typeof Card>;
 
@@ -32,7 +28,6 @@ const Template: ComponentStory<typeof Card> = ({ children, ...args }) => (
 
 const Default = Template.bind({});
 Default.args = {
-  size: "sm",
   variant: "filled",
 };
 
@@ -70,11 +65,7 @@ const loginForm = (
       Log in
     </CardHeader>
     <CardBody css={{ display: "flex", flexDirection: "column", gap: "10px" }}>
-      <TextInput
-        label="Email"
-        placeholder="Enter your email"
-        // description="e.g. name@example.com"
-      />
+      <TextInput label="Email" placeholder="Enter your email" />
       <TextInput
         label="Password"
         type="password"
@@ -83,11 +74,7 @@ const loginForm = (
       <Button>Continue</Button>
     </CardBody>
     <CardFooter css={{ textAlign: "center" }}>
-      <Button
-        as="a"
-        href="https://example.com"
-        variant="text"
-      >
+      <Button as="a" href="https://example.com" variant="text">
         Forgot your password?
       </Button>
     </CardFooter>
@@ -99,4 +86,5 @@ CardWithForm.args = {
   ...Default.args,
   children: loginForm,
   variant: "elevated",
+  css: { width: "280px" },
 };

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./card";
 export * from "./provider";
 export * from "./button";
 export * from "./input";

--- a/components/input/README.md
+++ b/components/input/README.md
@@ -4,7 +4,7 @@ A React component, intended to get user input
 
 ### Usage
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 
 function App() {
@@ -27,7 +27,7 @@ If you don't specify `variant` prop, default variant will be used.
 
 ### Usage
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 
 function App() {
@@ -53,7 +53,7 @@ If you don't specify `size` prop, default size will be used.
 
 ### Usage
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 
 function App() {
@@ -72,7 +72,7 @@ You can disable `TextInput` by specifying `disabled` property.
 
 ### Usage
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 
 function App() {
@@ -93,7 +93,7 @@ There are `icon` and `endIcon` properties to place icon at start or end of `Text
 
 ### Usage
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 import { IconSearch, IconMicrophone } from "@tabler/icons-react";
 
@@ -116,7 +116,7 @@ With `label` property `TextInput` renders with proper label. There is optional `
 
 ### Usage
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 
 function App() {
@@ -137,7 +137,7 @@ function App() {
 
 ### Usage
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 
 function App() {
@@ -157,7 +157,7 @@ When you validate you form input, you can provide `error` property to add error 
 
 ### Usage
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 
 function App() {
@@ -176,7 +176,7 @@ function App() {
 
 An example of controlled `TextInput` below.
 
-```typescript
+```jsx
 import { TextInput } from "spartak-ui";
 
 function App() {

--- a/components/input/TextInput.tsx
+++ b/components/input/TextInput.tsx
@@ -32,7 +32,7 @@ const InputComponent = styled("input", {
       },
       outlined: {
         backgroundColor: "transparent",
-        borderColor: "$grey500",
+        borderColor: "$grey400",
         "&:focus-visible": {
           borderColor: "$focus",
         },

--- a/components/input/index.ts
+++ b/components/input/index.ts
@@ -1,3 +1,1 @@
-import { TextInput } from "./TextInput";
-
-export { TextInput };
+export { TextInput } from "./TextInput";

--- a/components/provider/index.ts
+++ b/components/provider/index.ts
@@ -1,3 +1,1 @@
-import { ThemeProvider, useTheme } from "./ThemeProvider";
-
-export { useTheme, ThemeProvider };
+export { ThemeProvider, useTheme } from "./ThemeProvider";

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -3,7 +3,9 @@ import { createStitches, createTheme } from "@stitches/react";
 const grey = {
   grey000: "#ededed",
   // card background
-  grey400: "#f5f5f5",
+  grey300: "#f5f5f5",
+  // card outline border
+  grey400: "#eaeaea",
   grey500: "#999999",
   // text color
   grey700: "#333333",
@@ -12,7 +14,9 @@ const grey = {
 const greyDark = {
   grey000: "#3d3d3d",
   // card background
-  grey400: "#313335",
+  grey300: "#313335",
+  // card outline border
+  grey400: "#333536",
   grey500: "#8f8f8f",
   // text color
   grey700: "#ebebeb",
@@ -121,7 +125,9 @@ export const { theme, styled, globalCss } = createStitches({
     radii: {
       3: "3px",
     },
-    shadows: {},
+    shadows: {
+      boxShadow: "rgba(0, 0, 0, 0.24) 0px 1px 4px"
+    },
     zIndices: {},
     transitions: {},
   },

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -82,7 +82,7 @@ export const { theme, styled, globalCss } = createStitches({
       white: "#ffffff",
       focus: "#53B7DF",
       background: "#ffffff",
-      foreground: "#222222",
+      foreground: "#333333",
     },
     space: {
       iconGapXS: "4px",
@@ -126,7 +126,7 @@ export const { theme, styled, globalCss } = createStitches({
       3: "3px",
     },
     shadows: {
-      boxShadow: "rgba(0, 0, 0, 0.24) 0px 1px 4px"
+      boxShadow: "rgba(0, 0, 0, 0.24) 0px 1px 4px",
     },
     zIndices: {},
     transitions: {},
@@ -140,7 +140,7 @@ export const darkTheme = createTheme({
     ...greyDark,
     focus: "#70C4E5",
     background: "#232425",
-    foreground: "#ffffff",
+    foreground: "#f5f5f5",
   },
 });
 

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -2,6 +2,8 @@ import { createStitches, createTheme } from "@stitches/react";
 
 const grey = {
   grey000: "#ededed",
+  // card background
+  grey400: "#f5f5f5",
   grey500: "#999999",
   // text color
   grey700: "#333333",
@@ -9,6 +11,8 @@ const grey = {
 
 const greyDark = {
   grey000: "#3d3d3d",
+  // card background
+  grey400: "#313335",
   grey500: "#8f8f8f",
   // text color
   grey700: "#ebebeb",
@@ -78,13 +82,13 @@ export const { theme, styled, globalCss } = createStitches({
     },
     space: {
       iconGapXS: "4px",
-      paddingXS: '12px',
+      paddingXS: "12px",
       iconGapSM: "6px",
-      paddingSM: '14px',
+      paddingSM: "14px",
       iconGapMD: "8px",
-      paddingMD: '16px',
+      paddingMD: "16px",
       iconGapLG: "10px",
-      paddingLG: '18px',
+      paddingLG: "18px",
     },
     fontSizes: {
       xxs: "10px",
@@ -92,6 +96,7 @@ export const { theme, styled, globalCss } = createStitches({
       sm: "14px",
       md: "16px",
       lg: "18px",
+      xl: "20px",
     },
     fonts: {
       system:
@@ -110,7 +115,7 @@ export const { theme, styled, globalCss } = createStitches({
     },
     borderWidths: {
       1: "1px",
-      2: "2px"
+      2: "2px",
     },
     borderStyles: {},
     radii: {

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -4,8 +4,8 @@ const grey = {
   grey000: "#ededed",
   // card background
   grey300: "#f5f5f5",
-  // card outline border
-  grey400: "#eaeaea",
+  // outline border
+  grey400: "#c2c2c2",
   grey500: "#999999",
   // text color
   grey700: "#333333",
@@ -15,8 +15,8 @@ const greyDark = {
   grey000: "#3d3d3d",
   // card background
   grey300: "#313335",
-  // card outline border
-  grey400: "#333536",
+  // outline border
+  grey400: "#45484a",
   grey500: "#8f8f8f",
   // text color
   grey700: "#ebebeb",


### PR DESCRIPTION
**Description of changes**

`Card` contains content on a single subject. 

Example:

```jsx
import { Card, CardHeader, CardBody, CardFooter } from from "spartak-ui";

<Card>
  <CardHeader>
    <h2>Header</h2>
  </CardHeader>
  <CardBody>
    <p>Body</p>
  </CardBody>
  <CardFooter>
    <p>Footer</p>
  </CardFooter>
</Card>

```
**Component renders to semantic HTML elements**

`Card` renders to `<section>`, `CardBody` renders to `<div>`, `CardFooter>` renders to `<footer>`.


**API**:

- [x] `variant`: `filled`, `outlined`, `elevated`
- [ ] I updated docs and examples.

Resolves #30 