### PR TITLE
test(components): update tests to remove unsupported `toHaveStyle()` matcher

### DIFF
--- a/components/button/Button.test.tsx
+++ b/components/button/Button.test.tsx
@@ -2,7 +2,10 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Button } from "./Button";
 import { IconSun } from "@tabler/icons-react";
-import { theme } from "../stitches.config";
+
+const isClassSuffixPresent = (element: HTMLElement, value: string) => {
+  return [...element.classList].some((className) => className.endsWith(value));
+};
 
 describe("Button", () => {
   test("should renders", () => {
@@ -61,27 +64,34 @@ describe("Button", () => {
 
       //Act
       const button = screen.getByRole("button");
-      const isClassPresent = [...button.classList].some((className) =>
-        className.endsWith("variant-filled")
-      );
+      const result = isClassSuffixPresent(button, "variant-filled");
 
-      // Assess
-      expect(isClassPresent).toBe(true);
+      // Assert
+      expect(result).toBe(true);
     });
 
-    test("should renders with provided variant", () => {
-      // Arrange
-      render(<Button variant="outlined">Outlined button</Button>);
+    type VarianType = "filled" | "tinted" | "outlined" | "text";
+    type VariantTestData = [variant: VarianType, value: string];
+    const variantsToTest: VariantTestData[] = [
+      ["filled", "variant-filled"],
+      ["tinted", "variant-tinted"],
+      ["outlined", "variant-outlined"],
+      ["text", "variant-text"],
+    ];
+    test.each(variantsToTest)(
+      "should renders with %s variant",
+      (variant, expected) => {
+        // Arrange
+        render(<Button variant={variant}>{variant} variant</Button>);
 
-      //Act
-      const button = screen.getByRole("button");
-      const isClassPresent = [...button.classList].some((className) =>
-        className.endsWith("variant-outlined")
-      );
+        //Act
+        const button = screen.getByRole("button");
+        const result = isClassSuffixPresent(button, expected);
 
-      // Assess
-      expect(isClassPresent).toBe(true);
-    });
+        // Assert
+        expect(result).toBe(true);
+      }
+    );
   });
 
   describe("with size", () => {
@@ -91,30 +101,30 @@ describe("Button", () => {
 
       //Act
       const button = screen.getByRole("button");
-      const isClassPresent = [...button.classList].some((className) =>
-        className.endsWith("size-sm")
-      );
+      const result = isClassSuffixPresent(button, "size-sm");
 
-      // Assess
-      expect(isClassPresent).toBe(true);
+      // Assert
+      expect(result).toBe(true);
     });
 
-    const themeSizes = theme.sizes;
-    Object.keys(themeSizes).map((size) => {
-      const label = themeSizes[size as keyof typeof themeSizes].token;
+    type SizeType = "xs" | "sm" | "md" | "lg";
+    type SizeTestData = [size: SizeType, value: string];
+    const sizesToTest: SizeTestData[] = [
+      ["xs", "size-xs"],
+      ["sm", "size-sm"],
+      ["md", "size-md"],
+      ["lg", "size-lg"],
+    ];
+    test.each(sizesToTest)("should renders with %s size", (size, expected) => {
+      // Arrange
+      render(<Button size={size}>{size} size</Button>);
 
-      test(`should renders in ${label} size`, () => {
-        // Arrange
-        render(<Button size={label}>{label} size</Button>);
+      //Act
+      const button = screen.getByRole("button");
+      const result = isClassSuffixPresent(button, expected);
 
-        //Act
-        const button = screen.getByRole("button");
-
-        // Assess
-        expect(button).toHaveStyle(
-          `height: ${themeSizes[label]}, min-width: ${themeSizes[label]}`
-        );
-      });
+      // Assert
+      expect(result).toBe(true);
     });
   });
 
@@ -125,27 +135,32 @@ describe("Button", () => {
 
       //Act
       const button = screen.getByRole("button");
-      const isClassPresent = [...button.classList].some((className) =>
-        className.endsWith("color-red")
-      );
+      const result = isClassSuffixPresent(button, "color-red");
 
-      // Assess
-      expect(isClassPresent).toBe(true);
+      // Assert
+      expect(result).toBe(true);
     });
 
-    test("should renders with provided color", () => {
-      // Arrange
-      render(<Button color="blue">Blue button</Button>);
+    type ColorType = "red" | "blue";
+    type ColorTestData = [color: ColorType, value: string];
+    const colorsToTest: ColorTestData[] = [
+      ["red", "color-red"],
+      ["blue", "color-blue"],
+    ];
+    test.each(colorsToTest)(
+      "should renders with %s color",
+      (color, expected) => {
+        // Arrange
+        render(<Button color={color}>{color} color</Button>);
 
-      //Act
-      const button = screen.getByRole("button");
-      const isClassPresent = [...button.classList].some((className) =>
-        className.endsWith("color-blue")
-      );
+        //Act
+        const button = screen.getByRole("button");
+        const result = isClassSuffixPresent(button, expected);
 
-      // Assess
-      expect(isClassPresent).toBe(true);
-    });
+        // Assert
+        expect(result).toBe(true);
+      }
+    );
   });
 
   describe("with icon", () => {

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -24,8 +24,7 @@ const ButtonComponent = styled("button", {
     transition: "200ms",
   },
   "&:enabled:active": {
-    opacity: 0.8,
-    transition: "200ms",
+    transform: "scale(0.98)",
   },
   "&:disabled": {
     cursor: "not-allowed",

--- a/components/card/Card.test.tsx
+++ b/components/card/Card.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
 import { Card, CardHeader, CardBody, CardFooter } from "./Card";
-import { theme } from "../stitches.config";
 
 describe("Card", () => {
   test("should renders", () => {
@@ -60,7 +59,7 @@ describe("Card", () => {
         className.endsWith("variant-filled")
       );
 
-      // Assess
+      // Assert
       expect(isClassPresent).toBe(true);
     });
 
@@ -78,7 +77,7 @@ describe("Card", () => {
         className.endsWith("variant-filled")
       );
 
-      // Assess
+      // Assert
       expect(isClassPresent).toBe(true);
     });
 
@@ -96,7 +95,7 @@ describe("Card", () => {
         className.endsWith("variant-outlined")
       );
 
-      // Assess
+      // Assert
       expect(isClassPresent).toBe(true);
     });
 
@@ -114,7 +113,7 @@ describe("Card", () => {
         className.endsWith("variant-elevated")
       );
 
-      // Assess
+      // Assert
       expect(isClassPresent).toBe(true);
     });
   });

--- a/components/input/TextInput.test.tsx
+++ b/components/input/TextInput.test.tsx
@@ -1,8 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TextInput } from "./TextInput";
-import { theme } from "../stitches.config";
 import { IconSearch, IconMicrophone } from "@tabler/icons-react";
+
+const isClassSuffixPresent = (element: HTMLElement, value: string) => {
+  return [...element.classList].some((className) => className.endsWith(value));
+};
 
 describe("TextInput", () => {
   test("should renders", () => {
@@ -154,13 +157,11 @@ describe("TextInput", () => {
       // Act
       const error = screen.getByText("Invalid value");
       const input = screen.getByRole("textbox");
-      const isClassPresent = [...input.classList].some((className) =>
-        className.endsWith("isInvalid-true")
-      );
+      const result = isClassSuffixPresent(input, "isInvalid-true");
 
-      // Assess
+      // Assert
       expect(error).toBeInTheDocument();
-      expect(isClassPresent).toBe(true);
+      expect(result).toBe(true);
     });
 
     test("should show error not description", () => {
@@ -184,27 +185,32 @@ describe("TextInput", () => {
 
       //Act
       const input = screen.getByRole("textbox");
-      const isClassPresent = [...input.classList].some((className) =>
-        className.endsWith("variant-filled")
-      );
+      const result = isClassSuffixPresent(input, "variant-filled");
 
-      // Assess
-      expect(isClassPresent).toBe(true);
+      // Assert
+      expect(result).toBe(true);
     });
 
-    test("should renders with provided variant", () => {
-      // Arrange
-      render(<TextInput variant="outlined" />);
+    type VarianType = "filled" | "outlined";
+    type VariantTestData = [variant: VarianType, value: string];
+    const variantsToTest: VariantTestData[] = [
+      ["filled", "variant-filled"],
+      ["outlined", "variant-outlined"],
+    ];
+    test.each(variantsToTest)(
+      "should renders with %s variant",
+      (variant, expected) => {
+        // Arrange
+        render(<TextInput variant={variant} />);
 
-      //Act
-      const input = screen.getByRole("textbox");
-      const isClassPresent = [...input.classList].some((className) =>
-        className.endsWith("variant-outlined")
-      );
+        //Act
+        const input = screen.getByRole("textbox");
+        const result = isClassSuffixPresent(input, expected);
 
-      // Assess
-      expect(isClassPresent).toBe(true);
-    });
+        // Assert
+        expect(result).toBe(true);
+      }
+    );
   });
 
   describe("with size", () => {
@@ -214,34 +220,30 @@ describe("TextInput", () => {
 
       //Act
       const input = screen.getByRole("textbox");
-      const isClassPresent = [...input.classList].some((className) =>
-        className.endsWith("size-sm")
-      );
+      const result = isClassSuffixPresent(input, "size-sm");
 
-      // Assess
-      expect(isClassPresent).toBe(true);
+      // Assert
+      expect(result).toBe(true);
     });
 
-    const themeSizes = theme.sizes;
-    const themeSpaces = theme.space;
-    Object.keys(themeSizes).map((size) => {
-      const label = themeSizes[size as keyof typeof themeSizes].token;
-      const paddingLabel =
-        themeSpaces[`padding${label.toUpperCase()}` as keyof typeof themeSpaces]
-          .token;
+    type SizeType = "xs" | "sm" | "md" | "lg";
+    type SizeTestData = [size: SizeType, value: string];
+    const sizesToTest: SizeTestData[] = [
+      ["xs", "size-xs"],
+      ["sm", "size-sm"],
+      ["md", "size-md"],
+      ["lg", "size-lg"],
+    ];
+    test.each(sizesToTest)("should renders with %s size", (size, expected) => {
+      // Arrange
+      render(<TextInput size={size} />);
 
-      test(`should renders in ${label} size`, () => {
-        // Arrange
-        render(<TextInput size={label} />);
+      //Act
+      const input = screen.getByRole("textbox");
+      const result = isClassSuffixPresent(input, expected);
 
-        //Act
-        const input = screen.getByRole("textbox");
-
-        // Assess
-        expect(input).toHaveStyle(
-          `height: ${themeSizes[label]}, padding: 0 ${themeSpaces[paddingLabel]}`
-        );
-      });
+      // Assert
+      expect(result).toBe(true);
     });
   });
 


### PR DESCRIPTION
**Description of changes**

Update tests to remove `.toHaveStyle()` matcher, because of [the problem](https://github.com/stitchesjs/stitches/discussions/800) with `stitches` and `jsdom`.

Currently, component props are tested against class name suffixes like `class="<hash>-<prop name>-<prop value>"`, so the last part should be present on component class, e.g. `1u23kj-color-red`.

A discussion on how to test the actual styles of the design system is in the issue below.

Part of #8.