### PR TITLE
feat(text) add `Text` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Spartak UI
 
-A React Components Library
+A React Components Library.
+
+Check out [Storybook](https://shdq.github.io/spartak-ui/) for visual look of components.
 
 ## Components
 
 - [Button](https://github.com/shdq/spartak-ui/tree/main/components/button#button)
 - [Card](https://github.com/shdq/spartak-ui/tree/main/components/card#card)
 - [Input](https://github.com/shdq/spartak-ui/tree/main/components/input#textinput)
+- [Text](https://github.com/shdq/spartak-ui/tree/main/components/text#text)
 
 ## Examples built with Spartak UI
 

--- a/components/button/README.MD
+++ b/components/button/README.MD
@@ -69,7 +69,7 @@ There are four different sizes of `Button`:
 - `xs` – extra small sized button
 - `sm` (default) – small sized button
 - `md` – medium sized button
-- `lg` – large size button
+- `lg` – large sized button
 
 If you don't specify `size` prop, default size will be used.
 

--- a/components/button/README.MD
+++ b/components/button/README.MD
@@ -23,7 +23,7 @@ There are four different styles of `Button`:
 - `outlined`
 - `text`
 
-If you don't specify `variant` prop, default variant will be used.
+If you don't specify `variant` prop, the default variant will be used.
 
 ### Usage
 
@@ -46,7 +46,7 @@ There are several built-in `color` palettes available for `Button`:
 - `red` (default)
 - `blue`
 
-If you don't specify `color` prop, default variant will be used.
+If you don't specify `color` prop, the default variant will be used.
 
 ### Usage
 
@@ -71,7 +71,7 @@ There are four different sizes of `Button`:
 - `md` – medium sized button
 - `lg` – large sized button
 
-If you don't specify `size` prop, default size will be used.
+If you don't specify `size` prop, the default size will be used.
 
 ### Usage
 
@@ -89,7 +89,7 @@ function App() {
 
 ## Icons
 
-There are `icon` and `endIcon` properties to place icon before and after `Button` label.
+There are `icon` and `endIcon` properties to place icons before and after `Button` label.
 
 **NB:** `icon` property has a priority, if you use both properties, only one icon from `icon` will be rendered.
 
@@ -142,7 +142,7 @@ function App() {
 
 ## Button as a link
 
-Provide HTML element name `a` to `as` property and `href` with path or URL to render `Button` component as a link. If you provider only `href` it will be ignored.
+Provide HTML element name `a` to `as` property and `href` with path or URL to render `Button` component as a link. If you provide only `href` it will be ignored.
 
 ### Usage
 
@@ -164,7 +164,7 @@ function App() {
 
 ## Combined style
 
-You can combine variants. Example below will render blue tinted button.
+You can combine variants. The example below will render a blue, tinted button.
 
 ### Usage
 

--- a/components/card/README.md
+++ b/components/card/README.md
@@ -53,7 +53,13 @@ function App() {
 ### Usage
 
 ```jsx
-import { Card, CardHeader, CardBody, CardFooter } from from "spartak-ui";
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  Text
+} from from "spartak-ui";
 
 function App() {
   return (
@@ -62,10 +68,10 @@ function App() {
         <h2>Header</h2>
       </CardHeader>
       <CardBody>
-        <p>Body</p>
+        <Text>Body</Text>
       </CardBody>
       <CardFooter>
-        <p>Footer</p>
+        <Text>Footer</Text>
       </CardFooter>
     </Card>
   );

--- a/components/card/README.md
+++ b/components/card/README.md
@@ -2,7 +2,7 @@
 
 `Card` contains content on a single subject.
 
-It has `CardHeader`, `CardBody`, and `CardFooter` components to structure content inside card.
+It has `CardHeader`, `CardBody`, and `CardFooter` components to structure the content inside the card.
 
 ### Usage
 
@@ -28,7 +28,7 @@ There are three different styles of `Card`:
 - `outlined`
 - `elevated`
 
-If you don't specify `variant` prop, default variant will be used.
+If you don't specify `variant` prop, the default variant will be used.
 
 ### Usage
 
@@ -48,7 +48,7 @@ function App() {
 
 ## Card with full structure
 
-`CardFooter` is stick to the bottom of `Card`.
+`CardFooter` is sticky to the bottom of `Card`.
 
 ### Usage
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,5 @@
-export * from "./card";
-export * from "./provider";
 export * from "./button";
+export * from "./card";
 export * from "./input";
+export * from "./provider";
+export * from "./text";

--- a/components/input/README.md
+++ b/components/input/README.md
@@ -23,7 +23,7 @@ There are two different styles of `TextInput`:
 - `filled` (default)
 - `outlined`
 
-If you don't specify `variant` prop, default variant will be used.
+If you don't specify `variant` prop, the default variant will be used.
 
 ### Usage
 
@@ -49,7 +49,7 @@ There are four different sizes of `TextInput`:
 - `md` – medium
 - `lg` – large
 
-If you don't specify `size` prop, default size will be used.
+If you don't specify `size` prop, the default size will be used.
 
 ### Usage
 
@@ -87,7 +87,7 @@ function App() {
 
 ## Icons
 
-There are `icon` and `endIcon` properties to place icon at start or end of `TextInput`.
+There are `icon` and `endIcon` properties to place icons at the start and the end of `TextInput`.
 
 **NB:** You can use both properties to add both icons to `TextInput`
 
@@ -110,7 +110,7 @@ function App() {
 
 ## Label
 
-With `label` property `TextInput` renders with proper label. There is optional `required` property, which adds <sup>`*`</sup> to the `label`.
+With `label` property `TextInput` renders with the proper label. There is optional `required` property, which adds <sup>`*`</sup> to the `label`. You don't need to provide `id` or `for`, they will be generated for underneath HTML `input` and `label` elements automatically.
 
 **NB:** If you don't use `label` property, you should add `aria-label` to `TextInput` for accessibility purpose.
 
@@ -153,7 +153,7 @@ function App() {
 
 ## Error
 
-When you validate you form input, you can provide `error` property to add error message to the `TextInput`. It will highlight the input and replace description text with the error message.
+When you validate your form input, you can provide `error` property to add an error message to the `TextInput`. It will highlight the input and replace the description text with the error message.
 
 ### Usage
 
@@ -174,7 +174,7 @@ function App() {
 
 ## Controlled
 
-An example of controlled `TextInput` below.
+An example of controlled `TextInput`.
 
 ```jsx
 import { TextInput } from "spartak-ui";

--- a/components/text/README.md
+++ b/components/text/README.md
@@ -1,3 +1,137 @@
 # Text
 
-Text component
+`Text` displays text, links and other text information.
+
+### Usage
+
+```jsx
+import { Text } from "spartak-ui";
+
+function App() {
+  return (
+    <Text>
+      Example of text
+    </Text>;
+  );
+}
+```
+
+This example renders in HTML as `div`
+
+```html
+<div>Example of text</div>
+```
+
+## Sizes
+
+There are five different sizes of `Text`:
+
+- `xs` – extra small sized text
+- `sm` – small sized text
+- `md` – medium sized text
+- `lg` – large sized text
+- `xl` – extra large size text
+
+**NB**: By default font size is `inherited`. So you should specify size of the outer `Text` component.
+
+### Usage
+
+```jsx
+import { Text } from "spartak-ui";
+
+function App() {
+  return (
+    <Text size="lg">
+      Large text
+    </Text>;
+  );
+}
+```
+
+## Colors
+
+There are several built-in `color` palettes available for `Text`:
+
+- `red`
+- `blue`
+
+### Usage
+
+```jsx
+import { Text } from "spartak-ui";
+
+function App() {
+  return (
+    <Text color="red">
+      Text in red
+    </Text>;
+  );
+}
+```
+
+It is usefull if you need to render a link and color it. See example below.
+
+## Text as another element
+
+`Text` renders as `<div>` by default, if you need `<span>`, `<p>` or `a` provide HTML element name to `as` property.
+
+Some of HTML elements to render `Text` to:
+
+- `strong` – **bold**
+- `em` – *italic*
+- `u`- <u>underline</u>
+- `s` – <s>strikethrough</s>
+- `sup`- x<sup>2<sup>
+- and etc.
+
+Let's create a link with `href` with the URL. It will be underlined, but you also may specify the color.
+
+### Usage
+
+```jsx
+import { Text } from "spartak-ui";
+
+function App() {
+  return (
+    <Text as="p" size="md">
+      Text with 
+      <Text
+        as="a"
+        href="https://example.com"
+        color="red"
+      >
+      link
+      </Text>
+    </Text>
+  );
+}
+```
+
+This example renders in HTML as a medium-sized paragraph with the red underlined link inside:
+
+```html
+<p>Text with <a href="https://example.com">link</a></p>
+```
+
+## Secondary text
+
+If you want text to be dimmed, provide `secondary` boolean  property to `Text`.
+
+### Usage
+
+```jsx
+import { Text } from "spartak-ui";
+
+function App() {
+  return (
+    <>
+      <Text size="md">
+        Primary text
+      </Text>
+      <Text size="sm" secondary>
+        Supporting text
+      </Text>
+    </>
+  );
+}
+```

--- a/components/text/README.md
+++ b/components/text/README.md
@@ -1,0 +1,3 @@
+# Text
+
+Text component

--- a/components/text/README.md
+++ b/components/text/README.md
@@ -1,6 +1,6 @@
 # Text
 
-`Text` displays text, links and other text information.
+`Text` displays text, links, and other text information.
 
 ### Usage
 
@@ -26,13 +26,13 @@ This example renders in HTML as `div`
 
 There are five different sizes of `Text`:
 
-- `xs` – extra small sized text
+- `xs` – extra small-sized text
 - `sm` – small sized text
 - `md` – medium sized text
 - `lg` – large sized text
-- `xl` – extra large size text
+- `xl` – extra large sized text
 
-**NB**: By default font size is `inherited`. So you should specify size of the outer `Text` component.
+**NB**: By default font size is `inherited`. So you should specify the size of the outer `Text` component.
 
 ### Usage
 
@@ -69,13 +69,13 @@ function App() {
 }
 ```
 
-It is usefull if you need to render a link and color it. See example below.
+It is useful if you need to render a link and color it. See the example below.
 
 ## Text as another element
 
 `Text` renders as `<div>` by default, if you need `<span>`, `<p>` or `a` provide HTML element name to `as` property.
 
-Some of HTML elements to render `Text` to:
+Some of the HTML elements to render `Text` to:
 
 - `strong` – **bold**
 - `em` – *italic*
@@ -107,7 +107,7 @@ function App() {
 }
 ```
 
-This example renders in HTML as a medium-sized paragraph with the red underlined link inside:
+This example renders in HTML as a medium-sized paragraph with the red, underlined link inside:
 
 ```html
 <p>Text with <a href="https://example.com">link</a></p>
@@ -115,7 +115,7 @@ This example renders in HTML as a medium-sized paragraph with the red underlined
 
 ## Secondary text
 
-If you want text to be dimmed, provide `secondary` boolean  property to `Text`.
+If you want the text to be dimmed, provide `secondary` boolean property to `Text`.
 
 ### Usage
 

--- a/components/text/Text.test.tsx
+++ b/components/text/Text.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { Text } from "./Text";
+
+describe("Text", () => {
+  test("should renders", () => {
+    // Arrange
+    render(<Text>Example of text</Text>);
+
+    // Act
+    const text = screen.getByText("Example of text");
+
+    // Assert
+    expect(text).toBeInTheDocument();
+  });
+
+  test("should renders as <p>", () => {
+    // Arrange
+    render(<Text>Example of text</Text>);
+
+    // Act
+    const text = screen.getByText((text, element) => {
+      return (
+        element?.tagName.toLowerCase() === "p" && text === "Example of text"
+      );
+    });
+
+    // Assert
+    expect(text).toBeInTheDocument();
+  });
+  
+});

--- a/components/text/Text.test.tsx
+++ b/components/text/Text.test.tsx
@@ -17,19 +17,47 @@ describe("Text", () => {
     expect(text).toBeInTheDocument();
   });
 
-  test("should renders as <p>", () => {
+  test("should renders as <div>", () => {
     // Arrange
     render(<Text>Example of text</Text>);
 
     // Act
     const text = screen.getByText((text, element) => {
       return (
-        element?.tagName.toLowerCase() === "p" && text === "Example of text"
+        element?.tagName.toLowerCase() === "div" && text === "Example of text"
       );
     });
 
     // Assert
     expect(text).toBeInTheDocument();
+  });
+
+  test("should renders as another element", () => {
+    // Arrange
+    render(<Text as="strong">Example of strong text</Text>);
+
+    // Act
+    const text = screen.getByText((text, element) => {
+      return (
+        element?.tagName.toLowerCase() === "strong" &&
+        text === "Example of strong text"
+      );
+    });
+
+    // Assert
+    expect(text).toBeInTheDocument();
+  });
+
+  test("should renders as secondary (dimmed)", () => {
+    // Arrange
+    render(<Text secondary>Example of text</Text>);
+
+    // Act
+    const text = screen.getByText("Example of text");
+    const result = isClassSuffixPresent(text, "secondary-true");
+
+    // Assert
+    expect(result).toBe(true);
   });
 
   describe("with size", () => {

--- a/components/text/Text.test.tsx
+++ b/components/text/Text.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { Text } from "./Text";
 
+const isClassSuffixPresent = (element: HTMLElement, value: string) => {
+  return [...element.classList].some((className) => className.endsWith(value));
+};
+
 describe("Text", () => {
   test("should renders", () => {
     // Arrange
@@ -27,5 +31,39 @@ describe("Text", () => {
     // Assert
     expect(text).toBeInTheDocument();
   });
-  
+
+  describe("with size", () => {
+    test("should renders with default size when size isn't present", () => {
+      // Arrange
+      render(<Text>Example of text</Text>);
+
+      //Act
+      const text = screen.getByText("Example of text");
+      const result = isClassSuffixPresent(text, "size-sm");
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    type SizeType = "xs" | "sm" | "md" | "lg" | "xl";
+    type SizeTestData = [size: SizeType, value: string];
+    const sizesToTest: SizeTestData[] = [
+      ["xs", "size-xs"],
+      ["sm", "size-sm"],
+      ["md", "size-md"],
+      ["lg", "size-lg"],
+      ["xl", "size-xl"],
+    ];
+    test.each(sizesToTest)("should renders with %s size", (size, expected) => {
+      // Arrange
+      render(<Text size={size}>Example of text</Text>);
+
+      //Act
+      const text = screen.getByText("Example of text");
+      const result = isClassSuffixPresent(text, expected);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/components/text/Text.test.tsx
+++ b/components/text/Text.test.tsx
@@ -60,8 +60,59 @@ describe("Text", () => {
     expect(result).toBe(true);
   });
 
+  test("should renders as link", () => {
+    // Arrange
+    render(
+      <Text as="a" href="https://example.com">
+        Hyperlink
+      </Text>
+    );
+
+    // Act
+    const link = screen.getByRole("link");
+
+    // Assert
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "https://example.com");
+  });
+
+  describe("with color", () => {
+    test("should renders without default color", () => {
+      // Arrange
+      render(<Text>Example of text</Text>);
+
+      //Act
+      const text = screen.getByText("Example of text");
+      const result = isClassSuffixPresent(text, "color-red");
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    type ColorType = "red" | "blue";
+    type ColorTestData = [color: ColorType, value: string];
+    const colorsToTest: ColorTestData[] = [
+      ["red", "color-red"],
+      ["blue", "color-blue"],
+    ];
+    test.each(colorsToTest)(
+      "should renders with %s color",
+      (color, expected) => {
+        // Arrange
+        render(<Text color={color}>Example of text</Text>);
+
+        //Act
+        const text = screen.getByText("Example of text");
+        const result = isClassSuffixPresent(text, expected);
+
+        // Assert
+        expect(result).toBe(true);
+      }
+    );
+  });
+
   describe("with size", () => {
-    test("should renders with default size when size isn't present", () => {
+    test("should renders without default size", () => {
       // Arrange
       render(<Text>Example of text</Text>);
 
@@ -70,7 +121,7 @@ describe("Text", () => {
       const result = isClassSuffixPresent(text, "size-sm");
 
       // Assert
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
     type SizeType = "xs" | "sm" | "md" | "lg" | "xl";

--- a/components/text/Text.tsx
+++ b/components/text/Text.tsx
@@ -1,0 +1,3 @@
+import { styled } from "../stitches.config";
+
+export const Text = styled("p", {});

--- a/components/text/Text.tsx
+++ b/components/text/Text.tsx
@@ -1,3 +1,32 @@
 import { styled } from "../stitches.config";
 
-export const Text = styled("p", {});
+export const Text = styled("p", {
+  color: "$foreground",
+  fontFamily: "$system",
+  fontWeight: "$normal",
+  padding: 0,
+  margin: 0,
+
+  variants: {
+    size: {
+      xs: {
+        fontSize: "$xs",
+      },
+      sm: {
+        fontSize: "$sm",
+      },
+      md: {
+        fontSize: "$md",
+      },
+      lg: {
+        fontSize: "$lg",
+      },
+      xl: {
+        fontSize: "$xl",
+      },
+    },
+  },
+  defaultVariants: {
+    size: "sm",
+  },
+});

--- a/components/text/Text.tsx
+++ b/components/text/Text.tsx
@@ -1,6 +1,6 @@
 import { styled } from "../stitches.config";
 
-export const Text = styled("p", {
+export const Text = styled("div", {
   color: "$foreground",
   fontFamily: "$system",
   fontWeight: "$normal",
@@ -8,6 +8,11 @@ export const Text = styled("p", {
   margin: 0,
 
   variants: {
+    secondary: {
+      true: {
+        color: "$grey500",
+      },
+    },
     size: {
       xs: {
         fontSize: "$xs",

--- a/components/text/Text.tsx
+++ b/components/text/Text.tsx
@@ -4,13 +4,32 @@ export const Text = styled("div", {
   color: "$foreground",
   fontFamily: "$system",
   fontWeight: "$normal",
+  fontSize: "inherit",
   padding: 0,
   margin: 0,
+
+  "&[href]": {
+    textUnderlinePosition: "under",
+  },
 
   variants: {
     secondary: {
       true: {
         color: "$grey500",
+      },
+    },
+    color: {
+      red: {
+        color: "$red500",
+        "&[href]:hover": {
+          color: "$red600",
+        },
+      },
+      blue: {
+        color: "$blue500",
+        "&[href]:hover": {
+          color: "$blue600",
+        },
       },
     },
     size: {
@@ -30,8 +49,5 @@ export const Text = styled("div", {
         fontSize: "$xl",
       },
     },
-  },
-  defaultVariants: {
-    size: "sm",
   },
 });

--- a/components/text/index.ts
+++ b/components/text/index.ts
@@ -1,0 +1,1 @@
+export { Text } from "./Text";

--- a/components/text/stories/Text.stories.tsx
+++ b/components/text/stories/Text.stories.tsx
@@ -13,7 +13,12 @@ export default {
     ),
   ],
   component: Text,
-  argTypes: {},
+  argTypes: {
+    size: {
+      options: ["xs", "sm", "md", "lg"],
+      control: { type: "radio" },
+    },
+  },
 } as ComponentMeta<typeof Text>;
 
 const Template: ComponentStory<typeof Text> = ({ children, ...args }) => (
@@ -23,4 +28,17 @@ const Template: ComponentStory<typeof Text> = ({ children, ...args }) => (
 export const Default = Template.bind({});
 Default.args = {
   children: "Example of text",
+};
+
+export const Sizes = Template.bind({});
+Sizes.args = {
+  children: (
+    <>
+      <Text size="xs">The quick brown fox jumps over the lazy dog</Text>
+      <Text size="sm">The quick brown fox jumps over the lazy dog</Text>
+      <Text size="md">The quick brown fox jumps over the lazy dog</Text>
+      <Text size="lg">The quick brown fox jumps over the lazy dog</Text>
+      <Text size="xl">The quick brown fox jumps over the lazy dog</Text>
+    </>
+  ),
 };

--- a/components/text/stories/Text.stories.tsx
+++ b/components/text/stories/Text.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
+import { Text } from "../Text";
+
+export default {
+  title: "Components/Typography/Text",
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
+  component: Text,
+  argTypes: {},
+} as ComponentMeta<typeof Text>;
+
+const Template: ComponentStory<typeof Text> = ({ children, ...args }) => (
+  <Text {...args}>{children}</Text>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  children: "Example of text",
+};

--- a/components/text/stories/Text.stories.tsx
+++ b/components/text/stories/Text.stories.tsx
@@ -44,6 +44,26 @@ Sizes.args = {
   ),
 };
 
+export const Secondary = Template.bind({});
+Secondary.args = {
+  ...Default.args,
+  children: "Secondary text",
+  secondary: true,
+};
+
+export const AsLink = Template.bind({});
+AsLink.args = {
+  ...Default.args,
+  children: (
+    <>
+      Text with{" "}
+      <Text color="red" as="a" href="https://example.com">
+        hyperlink
+      </Text>
+    </>
+  ),
+};
+
 export const AsOtherElements = Template.bind({});
 AsOtherElements.args = {
   ...Default.args,
@@ -77,11 +97,4 @@ AsOtherElements.args = {
       </Text>
     </>
   ),
-};
-
-export const Secondary = Template.bind({});
-Secondary.args = {
-  ...Default.args,
-  children: "Secondary text",
-  secondary: true,
 };

--- a/components/text/stories/Text.stories.tsx
+++ b/components/text/stories/Text.stories.tsx
@@ -15,7 +15,7 @@ export default {
   component: Text,
   argTypes: {
     size: {
-      options: ["xs", "sm", "md", "lg"],
+      options: ["xs", "sm", "md", "lg", "xl"],
       control: { type: "radio" },
     },
   },
@@ -25,9 +25,10 @@ const Template: ComponentStory<typeof Text> = ({ children, ...args }) => (
   <Text {...args}>{children}</Text>
 );
 
-export const Default = Template.bind({});
+const Default = Template.bind({});
 Default.args = {
   children: "Example of text",
+  size: "sm",
 };
 
 export const Sizes = Template.bind({});
@@ -41,4 +42,46 @@ Sizes.args = {
       <Text size="xl">The quick brown fox jumps over the lazy dog</Text>
     </>
   ),
+};
+
+export const AsOtherElements = Template.bind({});
+AsOtherElements.args = {
+  ...Default.args,
+  children: (
+    <>
+      <Text>
+        <Text as="strong">Bold</Text>
+      </Text>
+      <Text>
+        <Text as="em">Italic</Text>
+      </Text>
+      <Text>
+        <Text as="u">Underline</Text>
+      </Text>
+      <Text>
+        <Text as="s">Strikethrough</Text>
+      </Text>
+      <Text>
+        2
+        <Text size="xs" as="sup">
+          2
+        </Text>{" "}
+        = 4
+      </Text>
+      <Text>
+        H
+        <Text size="xs" as="sub">
+          2
+        </Text>
+        O
+      </Text>
+    </>
+  ),
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  ...Default.args,
+  children: "Secondary text",
+  secondary: true,
 };


### PR DESCRIPTION
**Description**

This PR introduces `Text` component, which displays text, links, and other text information. It can be nested.

**Example**

```jsx
import { Text } from "spartak-ui";

function App() {
  return (
    <Text>
      Example of text
    </Text>;
  );
}
```

This example renders in HTML as `div`

```html
<div>Example of text</div>
```

**Extended example with `Text` as link**

```jsx
import { Text } from "spartak-ui";

function App() {
  return (
    <Text as="p" size="md">
      Text with 
      <Text
        as="a"
        href="https://example.com"
        color="red"
      >
      link
      </Text>
    </Text>
  );
}
```

This example renders in HTML as a medium-sized paragraph with the red, underlined link inside:

```html
<p>Text with <a href="https://example.com">link</a></p>
```

**API**

- `secondary` – render dimmed text
- `size` – `xs`, `sm`, `md`, `lg`, `xl` sizes of text
- `color` – `red`, `blue`
- `as` - render as another element, like `<a>` or `<span>`

- [x] I updated docs and examples.

Resolves #33 