### PR TITLE
feat(theme): add green palette

### DIFF
--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -52,6 +52,13 @@ const ButtonComponent = styled("button", {
         $$color500: "$colors$blue500",
         $$color600: "$colors$blue600",
       },
+      green: {
+        $$color000: "$colors$green000",
+        $$color100: "$colors$green100",
+        $$color400: "$colors$green400",
+        $$color500: "$colors$green500",
+        $$color600: "$colors$green600",
+      },
     },
 
     variant: {
@@ -76,28 +83,24 @@ const ButtonComponent = styled("button", {
         },
       },
       outlined: {
-        color: "$$color600",
-        borderColor: "$$color600",
+        color: "$$color400",
+        borderColor: "$$color400",
         backgroundColor: "transparent",
         "&:hover": {
-          color: "$$color400",
           backgroundColor: "$$color000",
         },
         "&:disabled": {
-          color: "$$color600",
           backgroundColor: "transparent",
         },
       },
       text: {
-        color: "$$color600",
+        color: "$$color400",
         borderColor: "transparent",
         backgroundColor: "transparent",
         "&:hover": {
-          color: "$$color400",
           backgroundColor: "$$color000",
         },
         "&:disabled": {
-          color: "$$color600",
           backgroundColor: "transparent",
         },
       },

--- a/components/button/README.MD
+++ b/components/button/README.MD
@@ -45,6 +45,7 @@ There are several built-in `color` palettes available for `Button`:
 
 - `red` (default)
 - `blue`
+- `green`
 
 If you don't specify `color` prop, the default variant will be used.
 

--- a/components/button/stories/Button.stories.tsx
+++ b/components/button/stories/Button.stories.tsx
@@ -42,7 +42,7 @@ export default {
       control: { type: "radio" },
     },
     color: {
-      options: ["red", "blue"],
+      options: ["red", "blue", "green"],
       control: { type: "radio" },
     },
     icon: {

--- a/components/examples/stories/YouTube.stories.tsx
+++ b/components/examples/stories/YouTube.stories.tsx
@@ -2,14 +2,14 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import App from "../YouTube/App";
 
 export default {
-  title: "Examples",
+  title: "UI Showcase",
   argTypes: {
     size: {
       options: ["xs", "sm", "md", "lg"],
       control: { type: "radio" },
     },
     color: {
-      options: ["red", "blue"],
+      options: ["red", "blue", "green"],
       control: { type: "radio" },
     },
   },
@@ -19,8 +19,8 @@ export default {
 const Template: ComponentStory<typeof App> = (args) => (
   <App {...args} />
 );
-export const Youtube = Template.bind({});
-Youtube.args = {
+export const YoutubeMenu = Template.bind({});
+YoutubeMenu.args = {
   color: "red",
   size: "md"
 }

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -30,9 +30,9 @@ const red = {
   // tinted text color
   red400: "#C72424",
   // common primary color between light and dark
-  red500: "#DE4D4D",
+  red500: "#D93333",
   // common hovered primary color between light and dark
-  red600: "#D93333",
+  red600: "#CF2626",
 };
 
 const redDark = {
@@ -41,11 +41,11 @@ const redDark = {
   // tinted hover background
   red100: "#570F0F",
   // text color for tinted and hovered text variant
-  red400: "#E36464",
+  red400: "#FF3131",
   // common primary color between light and dark
-  red500: "#DE4D4D",
+  red500: "#D93333",
   // common hovered primary color between light and dark
-  red600: "#D93333",
+  red600: "#CF2626",
 };
 
 const blue = {
@@ -54,23 +54,50 @@ const blue = {
   // tinted hover background
   blue100: "#C2D6FF",
   // tinted text color and hovered text variant
-  blue400: "#0A5CFF",
-  // common colors between light and dark
-  blue500: "#3377FF",
-  blue600: "#1F69FF",
+  blue400: "#355CEA",
+  // common primary color between light and dark
+  blue500: "#1F69FF",
+  // common hovered primary color between light and dark
+  blue600: "#0A5CFF",
 };
 
 const blueDark = {
   // tinted background
-  blue000: "#112B5F",
+  blue000: "#0C1F46",
   // tinted hover background
-  blue100: "#14326D",
+  blue100: "#0F2757",
   // color for tinted and hovered text variant
-  blue400: "#5C92FF",
+  blue400: "#4089FF",
   // common primary color between light and dark
-  blue500: "#3377FF",
+  blue500: "#1F69FF",
   // common hovered primary color between light and dark
-  blue600: "#1F69FF",
+  blue600: "#0A5CFF",
+};
+
+const green = {
+  // tinted background
+  green000: "#D8FFE0",
+  // tinted hover background
+  green100: "#ADFFBE",
+  // tinted text color and hovered text variant
+  green400: "#008F37",
+  // common primary color between light and dark
+  green500: "#00A33F",
+  // common hovered primary color between light and dark
+  green600: "#008F37",
+};
+
+const greenDark = {
+  // tinted background
+  green000: "#0D4A1A",
+  // tinted hover background
+  green100: "#0F5711",
+  // color for tinted and hovered text variant
+  green400: "#00CC4E",
+  // common colors between light and dark
+  green500: "#00A33F",
+  // common hovered primary color between light and dark
+  green600: "#008F37",
 };
 
 export const { theme, styled, globalCss } = createStitches({
@@ -78,6 +105,7 @@ export const { theme, styled, globalCss } = createStitches({
     colors: {
       ...red,
       ...blue,
+      ...green,
       ...grey,
       white: "#ffffff",
       focus: "#53B7DF",
@@ -137,6 +165,7 @@ export const darkTheme = createTheme({
   colors: {
     ...redDark,
     ...blueDark,
+    ...greenDark,
     ...greyDark,
     focus: "#70C4E5",
     background: "#232425",

--- a/components/text/README.md
+++ b/components/text/README.md
@@ -54,6 +54,7 @@ There are several built-in `color` palettes available for `Text`:
 
 - `red`
 - `blue`
+- `green`
 
 ### Usage
 


### PR DESCRIPTION
**Description**

`green` palette added to Spartak UI theme.

Props updated with the corresponding value, some colors adjusted for the `Button` component.

Example

```jsx
import { Button } from "spartak-ui";

function App() {
  return (
    <Button color="green">
      Green button
    </Button>;
  );
}
```

- [x] I updated docs and examples.

Resolves #37 