### PR TITLE
feat(heading): add `Heading` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,19 @@ A collection of React components
 
 ## Components
 
+**Forms**
+
 - [Button](https://github.com/shdq/spartak-ui/tree/main/components/button#button)
-- [Card](https://github.com/shdq/spartak-ui/tree/main/components/card#card)
 - [Input](https://github.com/shdq/spartak-ui/tree/main/components/input#textinput)
+
+**Typography**
+
+- [Heading](https://github.com/shdq/spartak-ui/tree/main/components/heading#heading)
 - [Text](https://github.com/shdq/spartak-ui/tree/main/components/text#text)
+
+**Display content**
+
+- [Card](https://github.com/shdq/spartak-ui/tree/main/components/card#card)
 
 Check out [Storybook](https://shdq.github.io/spartak-ui/) for visual look of the components.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Check out [Storybook](https://shdq.github.io/spartak-ui/) for visual look of the
 
 ## Examples built with Spartak UI
 
-- [Spotify Playlists](https://shdq.github.io/spartak-ui/?path=/story/ui-showcase--spotify-playlists) with `Button`, `Card`, and `Text` components
+- [Spotify Playlists](https://shdq.github.io/spartak-ui/?path=/story/ui-showcase--spotify-playlists) with `Button`, `Card`, `Heading` and `Text` components
 - [YouTube Side Menu](https://shdq.github.io/spartak-ui/?path=/story/ui-showcase--youtube-menu) with `Button` component
 
 ## Dark theme

--- a/components/examples/Spotify/App.tsx
+++ b/components/examples/Spotify/App.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from "../../index";
 import { styled } from "../../stitches.config";
 import { IconPlayerPlayFilled } from "@tabler/icons-react";
-import { Button, Text } from "../../index";
+import { Button, Heading, Text } from "../../index";
 import { Card, CardHeader, CardBody } from "../../index";
 import { Switch } from "../../provider/Switch";
 
@@ -85,9 +85,9 @@ const App = ({ color, variant }: AppProps) => {
             color={color}
             icon={<IconPlayerPlayFilled size={22} />}
           />
-          <Text as="h2" size="md" css={{ paddingTop: "8px", fontWeight: 500 }}>
+          <Heading size="xs" css={{ paddingTop: "8px" }}>
             {title}
-          </Text>
+          </Heading>
         </CardHeader>
         <CardBody
           css={{

--- a/components/heading/Heading.test.tsx
+++ b/components/heading/Heading.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { Heading } from "./Heading";
+
+const isClassSuffixPresent = (element: HTMLElement, value: string) => {
+  return [...element.classList].some((className) => className.endsWith(value));
+};
+
+describe("Heading", () => {
+  test("should renders", () => {
+    // Arrange
+    render(<Heading>Example of heading</Heading>);
+
+    // Act
+    const heading = screen.getByText("Example of heading");
+
+    // Assert
+    expect(heading).toBeInTheDocument();
+  });
+
+  test("should renders as <h2>", () => {
+    // Arrange
+    render(<Heading>Example of heading</Heading>);
+
+    // Act
+    const heading = screen.getByText((text, element) => {
+      return (
+        element?.tagName.toLowerCase() === "h2" && text === "Example of heading"
+      );
+    });
+
+    // Assert
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/components/heading/Heading.test.tsx
+++ b/components/heading/Heading.test.tsx
@@ -32,6 +32,21 @@ describe("Heading", () => {
     expect(heading).toBeInTheDocument();
   });
 
+  test("should renders as another level element", () => {
+    // Arrange
+    render(<Heading as="h1">Level 1 heading</Heading>);
+
+    // Act
+    const heading = screen.getByText((text, element) => {
+      return (
+        element?.tagName.toLowerCase() === "h1" && text === "Level 1 heading"
+      );
+    });
+
+    // Assert
+    expect(heading).toBeInTheDocument();
+  });
+
   describe("with size", () => {
     test("should renders in default size", () => {
       // Arrange

--- a/components/heading/Heading.test.tsx
+++ b/components/heading/Heading.test.tsx
@@ -31,4 +31,40 @@ describe("Heading", () => {
     // Assert
     expect(heading).toBeInTheDocument();
   });
+
+  describe("with size", () => {
+    test("should renders in default size", () => {
+      // Arrange
+      render(<Heading>Example of heading</Heading>);
+
+      //Act
+      const heading = screen.getByText("Example of heading");
+      const result = isClassSuffixPresent(heading, "size-sm");
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    type SizeType = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
+    type SizeTestData = [size: SizeType, value: string];
+    const sizesToTest: SizeTestData[] = [
+      ["xs", "size-xs"],
+      ["sm", "size-sm"],
+      ["md", "size-md"],
+      ["lg", "size-lg"],
+      ["xl", "size-xl"],
+      ["xxl", "size-xxl"],
+    ];
+    test.each(sizesToTest)("should renders with %s size", (size, expected) => {
+      // Arrange
+      render(<Heading size={size}>Example of heading</Heading>);
+
+      //Act
+      const heading = screen.getByText("Example of heading");
+      const result = isClassSuffixPresent(heading, expected);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/components/heading/Heading.tsx
+++ b/components/heading/Heading.tsx
@@ -1,3 +1,35 @@
 import { styled } from "../stitches.config";
 
-export const Heading = styled("h2", {});
+export const Heading = styled("h2", {
+  color: "$foreground",
+  fontFamily: "$system",
+  fontWeight: "$bold",
+  padding: 0,
+  margin: 0,
+
+  variants: {
+    size: {
+      xs: {
+        fontSize: "$headingXS",
+      },
+      sm: {
+        fontSize: "$headingSM",
+      },
+      md: {
+        fontSize: "$headingMD",
+      },
+      lg: {
+        fontSize: "$headingLG",
+      },
+      xl: {
+        fontSize: "$headingXL",
+      },
+      xxl: {
+        fontSize: "$headingXXL",
+      },
+    },
+  },
+  defaultVariants: {
+    size: "sm",
+  },
+});

--- a/components/heading/Heading.tsx
+++ b/components/heading/Heading.tsx
@@ -1,0 +1,3 @@
+import { styled } from "../stitches.config";
+
+export const Heading = styled("h2", {});

--- a/components/heading/README.md
+++ b/components/heading/README.md
@@ -19,7 +19,7 @@ function App() {
 This example renders in HTML as `h2` by default
 
 ```html
-<h2>Example of text</h2>
+<h2>Hello world!</h2>
 ```
 
 ## Heading levels

--- a/components/heading/README.md
+++ b/components/heading/README.md
@@ -1,6 +1,6 @@
 # Heading
 
-`Heading` displays any type of headers.
+`Heading` displays any type of titles with corresponding HTML elements.
 
 ### Usage
 
@@ -11,6 +11,57 @@ function App() {
   return (
     <Heading>
       Hello world!
+    </Heading>;
+  );
+}
+```
+
+This example renders in HTML as `h2` by default
+
+```html
+<h2>Example of text</h2>
+```
+
+## Heading levels
+
+For rendering as `h1`, `h2`, `h3`, `h4`, `h5`, and `h6` provide needed level to `as` property.
+
+### Usage
+
+```jsx
+import { Heading } from "spartak-ui";
+
+function App() {
+  return (
+    <Heading as="h1">
+      Title of the page
+    </Heading>;
+  );
+}
+```
+
+## Sizes
+
+There are six different sizes of `Heading`:
+
+- `xs` – extra small
+- `sm` (default) – small
+- `md` – medium
+- `lg` – large
+- `xl` – extra large
+- `xxl` – double extra large
+
+**NB**: If you don't specify `size` prop, the default size will be used.
+
+### Usage
+
+```jsx
+import { Heading } from "spartak-ui";
+
+function App() {
+  return (
+    <Heading size="lg">
+      Large title
     </Heading>;
   );
 }

--- a/components/heading/README.md
+++ b/components/heading/README.md
@@ -1,0 +1,17 @@
+# Heading
+
+`Heading` displays any type of headers.
+
+### Usage
+
+```jsx
+import { Heading } from "spartak-ui";
+
+function App() {
+  return (
+    <Heading>
+      Hello world!
+    </Heading>;
+  );
+}
+```

--- a/components/heading/index.ts
+++ b/components/heading/index.ts
@@ -1,0 +1,1 @@
+export { Heading } from "./Heading";

--- a/components/heading/stories/Heading.stories.tsx
+++ b/components/heading/stories/Heading.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
+import { Heading } from "../Heading";
+
+export default {
+  title: "Components/Typography/Heading",
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
+  component: Heading,
+  argTypes: {},
+} as ComponentMeta<typeof Heading>;
+
+const Template: ComponentStory<typeof Heading> = ({ children, ...args }) => (
+  <Heading {...args}>{children}</Heading>
+);
+
+export const Basic = Template.bind({});
+Basic.args = {
+  children: "Hello world",
+};

--- a/components/heading/stories/Heading.stories.tsx
+++ b/components/heading/stories/Heading.stories.tsx
@@ -25,8 +25,8 @@ const Template: ComponentStory<typeof Heading> = ({ children, ...args }) => (
   <Heading {...args}>{children}</Heading>
 );
 
-export const Basic = Template.bind({});
-Basic.args = {
+const Default = Template.bind({});
+Default.args = {
   children: "Hello world",
   size: "sm",
 };
@@ -43,4 +43,31 @@ Sizes.args = {
       <Heading size="xs">Title of the page in XS size</Heading>
     </>
   ),
+};
+
+export const WithSupportingText = Template.bind({});
+WithSupportingText.args = {
+  children: (
+    <>
+      Awesome title.{" "}
+      <Text as="span" secondary>
+        I support it.
+      </Text>
+    </>
+  ),
+  size: "xl",
+};
+
+export const WithLink = Template.bind({});
+WithLink.args = {
+  children: (
+    <>
+      Title with{" "}
+      <Text color="red" as="a" href="https://example.com">
+        hyperlink
+      </Text>{" "}
+      in it
+    </>
+  ),
+  size: "xl",
 };

--- a/components/heading/stories/Heading.stories.tsx
+++ b/components/heading/stories/Heading.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { useDarkMode } from "storybook-dark-mode";
 import { darkTheme } from "../../stitches.config";
-import { Heading } from "../Heading";
+import { Heading, Text } from "../../index";
 
 export default {
   title: "Components/Typography/Heading",
@@ -13,7 +13,12 @@ export default {
     ),
   ],
   component: Heading,
-  argTypes: {},
+  argTypes: {
+    size: {
+      options: ["xs", "sm", "md", "lg", "xl", "xxl"],
+      control: { type: "radio" },
+    },
+  },
 } as ComponentMeta<typeof Heading>;
 
 const Template: ComponentStory<typeof Heading> = ({ children, ...args }) => (
@@ -23,4 +28,19 @@ const Template: ComponentStory<typeof Heading> = ({ children, ...args }) => (
 export const Basic = Template.bind({});
 Basic.args = {
   children: "Hello world",
+  size: "sm",
+};
+
+export const Sizes = Template.bind({});
+Sizes.args = {
+  children: (
+    <>
+      <Heading size="xxl">Title of the page in XXL size</Heading>
+      <Heading size="xl">Title of the page in XL size</Heading>
+      <Heading size="lg">Title of the page in LG size</Heading>
+      <Heading size="md">Title of the page in MD size</Heading>
+      <Heading size="sm">Title of the page in SM size</Heading>
+      <Heading size="xs">Title of the page in XS size</Heading>
+    </>
+  ),
 };

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./button";
 export * from "./card";
+export * from "./heading";
 export * from "./input";
 export * from "./provider";
 export * from "./text";

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -129,6 +129,13 @@ export const { theme, styled, globalCss } = createStitches({
       md: "16px",
       lg: "18px",
       xl: "20px",
+
+      headingXS: "16px",
+      headingSM: "18px",
+      headingMD: "22px",
+      headingLG: "26px",
+      headingXL: "30px",
+      headingXXL: "40px",
     },
     fonts: {
       system:
@@ -136,6 +143,7 @@ export const { theme, styled, globalCss } = createStitches({
     },
     fontWeights: {
       normal: 400,
+      bold: 600,
     },
     lineHeights: {},
     letterSpacings: {},


### PR DESCRIPTION
**Description**

This PR introduces `Heading` component, which displays any type of titles with corresponding HTML elements.

**Example**

```jsx
import { Heading } from "spartak-ui";

function App() {
  return (
    <Heading>
      Hello world!
    </Heading>;
  );
}
```

This example renders in HTML as `h2` by default:

```html
<h2>Hello world!</h2>
```

**Example with level one header and `xl` size**

```jsx
import { Heading } from "spartak-ui";

function App() {
  return (
    <Heading as="h1" size="xl">
      Large title of the page
    </Heading>;
  );
}
```

This example renders in HTML as a medium-sized paragraph with the red, underlined link inside:

```html
<h1>Large title of the page</h1>
```

**API**

- `size` – `xs`, `sm`, `md`, `lg`, `xl`, `xxl` sizes of heading
- `as` - render as as `h1`, `h2`, `h3`, `h4`, `h5`, and `h6` elements

- [x] I updated the docs and examples.

Resolves #36 