### PR TITLE
fix(text): add missing green palette to `Text` component

### DIFF
--- a/components/text/Text.tsx
+++ b/components/text/Text.tsx
@@ -31,6 +31,12 @@ export const Text = styled("div", {
           color: "$blue600",
         },
       },
+      green: {
+        color: "$green500",
+        "&[href]:hover": {
+          color: "$green600",
+        },
+      },
     },
     size: {
       xs: {


### PR DESCRIPTION
**Description**

Add the missing `green` palette to the `Text` component.

Part of #37