### PR TITLE
feat(avatar): add `Avatar` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A collection of React components
 
 **Display content**
 
+- [Avatar](https://github.com/shdq/spartak-ui/tree/main/components/avatar#avatar)
 - [Card](https://github.com/shdq/spartak-ui/tree/main/components/card#card)
 
 Check out [Storybook](https://shdq.github.io/spartak-ui/) for visual look of the components.

--- a/components/avatar/Avatar.tsx
+++ b/components/avatar/Avatar.tsx
@@ -1,0 +1,3 @@
+import { styled } from "../stitches.config";
+
+export const Avatar = styled("div", {});

--- a/components/avatar/Avatar.tsx
+++ b/components/avatar/Avatar.tsx
@@ -1,11 +1,10 @@
 import { styled } from "../stitches.config";
 
 const AvatarComponent = styled("div", {
+  position: "relative",
   borderRadius: "$3",
   fontFamily: "$system",
   fontWeight: "$bold",
-  overflow: "hidden",
-
   color: "$grey700",
   backgroundColor: "$grey400",
 
@@ -15,29 +14,45 @@ const AvatarComponent = styled("div", {
         borderRadius: "9999px",
       },
     },
+    status: {
+      online: {
+        $$badgeColor: "$colors$green500",
+      },
+      offline: {
+        $$badgeColor: "$colors$red500",
+      },
+      unread: {
+        $$badgeColor: "$colors$blue500",
+      },
+    },
     size: {
       xs: {
         fontSize: "12px",
         width: "24px",
         height: "24px",
+        $$borderWidth: "$borderWidths$1",
       },
       sm: {
         fontSize: "16px",
         width: "32px",
         height: "32px",
+        $$borderWidth: "$borderWidths$2",
       },
       md: {
         fontSize: "24px",
         width: "48px",
         height: "48px",
+        $$borderWidth: "$borderWidths$2",
       },
       lg: {
         fontSize: "32px",
         width: "64px",
         height: "64px",
+        $$borderWidth: "$borderWidths$3",
       },
     },
   },
+
   defaultVariants: {
     size: "sm",
   },
@@ -63,44 +78,58 @@ const Wrapper = styled("div", {
   justifyContent: "center",
   alignItems: "center",
   userSelect: "none",
+  overflow: "hidden",
+  borderRadius: "inherit",
+});
+
+const Badge = styled("div", {
+  position: "absolute",
+  bottom: "-0.25em",
+  right: "-0.25em",
+  backgroundColor: "$$badgeColor",
+  width: "0.6em",
+  height: "0.6em",
+  border: "$$borderWidth solid $colors$background",
+  borderRadius: "9999px",
+  variants: {
+    round: {
+      true: {
+        bottom: "-$$borderWidth",
+        right: "-$$borderWidth",
+      },
+    },
+  },
 });
 
 export const Avatar = ({
   src,
   alt,
   icon,
+  status,
+  round,
   size = "sm",
   children,
   ...props
 }: AvatarProps) => {
-  if (src) {
-    const label = size as keyof typeof sizes;
-    return (
-      <AvatarComponent size={size} {...props}>
-        <Wrapper>
+  const label = size as keyof typeof sizes;
+  return (
+    <AvatarComponent status={status} round={round} size={size} {...props}>
+      <Wrapper>
+        {src ? (
           <img
             alt={alt}
             draggable={false}
             width={sizes[label]}
             height={sizes[label]}
             src={src}
-          ></img>
-        </Wrapper>
-      </AvatarComponent>
-    );
-  }
-
-  if (icon) {
-    return (
-      <AvatarComponent size={size} {...props}>
-        <Wrapper>{icon}</Wrapper>
-      </AvatarComponent>
-    );
-  }
-
-  return (
-    <AvatarComponent size={size} {...props}>
-      <Wrapper>{children}</Wrapper>
+          />
+        ) : icon ? (
+          icon
+        ) : (
+          children
+        )}
+        {status && <Badge data-testid="status-badge" round={round} />}
+      </Wrapper>
     </AvatarComponent>
   );
 };

--- a/components/avatar/Avatar.tsx
+++ b/components/avatar/Avatar.tsx
@@ -6,7 +6,7 @@ const AvatarComponent = styled("div", {
   fontWeight: "$bold",
   overflow: "hidden",
 
-  color: "$foreground",
+  color: "$grey700",
   backgroundColor: "$grey400",
 
   variants: {
@@ -46,6 +46,7 @@ const AvatarComponent = styled("div", {
 export type AvatarProps = React.ComponentProps<typeof AvatarComponent> & {
   src?: string;
   alt?: string;
+  icon?: React.ReactNode;
 };
 
 const sizes = {
@@ -85,6 +86,14 @@ export const Avatar = ({
             src={src}
           ></img>
         </Wrapper>
+      </AvatarComponent>
+    );
+  }
+
+  if (icon) {
+    return (
+      <AvatarComponent size={size} {...props}>
+        <Wrapper>{icon}</Wrapper>
       </AvatarComponent>
     );
   }

--- a/components/avatar/Avatar.tsx
+++ b/components/avatar/Avatar.tsx
@@ -5,13 +5,29 @@ const AvatarComponent = styled("div", {
   borderRadius: "$3",
   fontFamily: "$system",
   fontWeight: "$bold",
-  color: "$grey700",
-  backgroundColor: "$grey400",
 
   variants: {
     round: {
       true: {
         borderRadius: "9999px",
+      },
+    },
+    color: {
+      grey: {
+        color: "$grey700",
+        backgroundColor: "$grey400",
+      },
+      red: {
+        color: "$red400",
+        backgroundColor: "$red000",
+      },
+      green: {
+        color: "$green400",
+        backgroundColor: "$green000",
+      },
+      blue: {
+        color: "$blue400",
+        backgroundColor: "$blue000",
       },
     },
     status: {
@@ -58,6 +74,7 @@ const AvatarComponent = styled("div", {
 
   defaultVariants: {
     size: "sm",
+    color: "grey",
   },
 });
 

--- a/components/avatar/Avatar.tsx
+++ b/components/avatar/Avatar.tsx
@@ -18,8 +18,11 @@ const AvatarComponent = styled("div", {
       online: {
         $$badgeColor: "$colors$green500",
       },
-      offline: {
+      busy: {
         $$badgeColor: "$colors$red500",
+      },
+      offline: {
+        $$badgeColor: "$colors$grey500",
       },
       unread: {
         $$badgeColor: "$colors$blue500",
@@ -128,7 +131,13 @@ export const Avatar = ({
         ) : (
           children
         )}
-        {status && <Badge data-testid="status-badge" round={round} />}
+        {status && (
+          <Badge
+            data-testid="status-badge"
+            title={status.toString()}
+            round={round}
+          />
+        )}
       </Wrapper>
     </AvatarComponent>
   );

--- a/components/avatar/Avatar.tsx
+++ b/components/avatar/Avatar.tsx
@@ -1,3 +1,97 @@
 import { styled } from "../stitches.config";
 
-export const Avatar = styled("div", {});
+const AvatarComponent = styled("div", {
+  borderRadius: "$3",
+  fontFamily: "$system",
+  fontWeight: "$bold",
+  overflow: "hidden",
+
+  color: "$foreground",
+  backgroundColor: "$grey400",
+
+  variants: {
+    round: {
+      true: {
+        borderRadius: "9999px",
+      },
+    },
+    size: {
+      xs: {
+        fontSize: "12px",
+        width: "24px",
+        height: "24px",
+      },
+      sm: {
+        fontSize: "16px",
+        width: "32px",
+        height: "32px",
+      },
+      md: {
+        fontSize: "24px",
+        width: "48px",
+        height: "48px",
+      },
+      lg: {
+        fontSize: "32px",
+        width: "64px",
+        height: "64px",
+      },
+    },
+  },
+  defaultVariants: {
+    size: "sm",
+  },
+});
+
+export type AvatarProps = React.ComponentProps<typeof AvatarComponent> & {
+  src?: string;
+  alt?: string;
+};
+
+const sizes = {
+  xs: "24px",
+  sm: "32px",
+  md: "48px",
+  lg: "64px",
+};
+
+const Wrapper = styled("div", {
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  userSelect: "none",
+});
+
+export const Avatar = ({
+  src,
+  alt,
+  icon,
+  size = "sm",
+  children,
+  ...props
+}: AvatarProps) => {
+  if (src) {
+    const label = size as keyof typeof sizes;
+    return (
+      <AvatarComponent size={size} {...props}>
+        <Wrapper>
+          <img
+            alt={alt}
+            draggable={false}
+            width={sizes[label]}
+            height={sizes[label]}
+            src={src}
+          ></img>
+        </Wrapper>
+      </AvatarComponent>
+    );
+  }
+
+  return (
+    <AvatarComponent size={size} {...props}>
+      <Wrapper>{children}</Wrapper>
+    </AvatarComponent>
+  );
+};

--- a/components/avatar/Avatart.test.tsx
+++ b/components/avatar/Avatart.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import { Avatar } from "./Avatar";
+import { IconUser } from "@tabler/icons-react";
 
 const isClassSuffixPresent = (element: HTMLElement, value: string) => {
   return [...element.classList].some((className) => className.endsWith(value));
@@ -63,6 +64,48 @@ describe("Avatar", () => {
 
       // Assert
       expect(img).toHaveAttribute("alt", "userpic");
+    });
+  });
+
+  describe("with icon", () => {
+    test("should renders with icon", () => {
+      // Arrange
+      render(
+        <Avatar
+          icon={<IconUser data-testid="svg-icon" />}
+          data-testid="avatar"
+        />
+      );
+
+      //Act
+      const avatar = screen.getByTestId("avatar");
+      const icon = within(avatar).getByTestId("svg-icon");
+
+      // Assert
+      expect(icon).toBeInTheDocument();
+    });
+
+    test("should ignore icon if src is present", () => {
+      // Arrange
+      render(
+        <Avatar
+          src="user.png"
+          alt="userpic"
+          icon={<IconUser data-testid="svg-icon" />}
+          data-testid="avatar"
+        />
+      );
+
+      // Act
+      const avatar = screen.getByTestId("avatar");
+      const img = within(avatar).getByRole("img");
+      // queryBy doesn't throw error, and returns null
+      const icon = within(avatar).queryByTestId("svg-icon");
+
+      // Assert
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute("alt", "userpic");
+      expect(icon).toBeNull();
     });
   });
 

--- a/components/avatar/Avatart.test.tsx
+++ b/components/avatar/Avatart.test.tsx
@@ -119,6 +119,7 @@ describe("Avatar", () => {
 
       // Assert
       expect(badge).toBeInTheDocument();
+      expect(badge).toHaveAttribute("title", "online");
     });
   });
 

--- a/components/avatar/Avatart.test.tsx
+++ b/components/avatar/Avatart.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { Avatar } from "./Avatar";
+
+describe("Avatar", () => {
+  test("should renders", () => {
+    // Arrange
+    render(<Avatar data-testid="avatar" />);
+    const avatar = screen.getByTestId("avatar");
+
+    // Act & Assert
+    expect(avatar).toBeInTheDocument();
+  });
+});

--- a/components/avatar/Avatart.test.tsx
+++ b/components/avatar/Avatart.test.tsx
@@ -123,6 +123,43 @@ describe("Avatar", () => {
     });
   });
 
+  describe("with color", () => {
+    test("should renders with default color when color isn't present", () => {
+      // Arrange
+      render(<Avatar data-testid="avatar">SC</Avatar>);
+
+      //Act
+      const avatar = screen.getByTestId("avatar");
+      const result = isClassSuffixPresent(avatar, "color-grey");
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    type ColorType = "grey" | "red" | "green" | "blue";
+    type ColorTestData = [color: ColorType, value: string];
+    const colorsToTest: ColorTestData[] = [
+      ["grey", "color-grey"],
+      ["red", "color-red"],
+      ["green", "color-green"],
+      ["blue", "color-blue"],
+    ];
+    test.each(colorsToTest)(
+      "should renders with %s color",
+      (color, expected) => {
+        // Arrange
+        render(<Avatar color={color} data-testid="avatar">SC</Avatar>);
+
+        //Act
+        const avatar = screen.getByTestId("avatar");
+        const result = isClassSuffixPresent(avatar, expected);
+
+        // Assert
+        expect(result).toBe(true);
+      }
+    );
+  });
+
   describe("with size", () => {
     test("should renders with default size when size isn't present", () => {
       // Arrange

--- a/components/avatar/Avatart.test.tsx
+++ b/components/avatar/Avatart.test.tsx
@@ -1,5 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { Avatar } from "./Avatar";
+
+const isClassSuffixPresent = (element: HTMLElement, value: string) => {
+  return [...element.classList].some((className) => className.endsWith(value));
+};
 
 describe("Avatar", () => {
   test("should renders", () => {
@@ -9,5 +13,94 @@ describe("Avatar", () => {
 
     // Act & Assert
     expect(avatar).toBeInTheDocument();
+  });
+
+  test("should have placeholder", () => {
+    // Arrange
+    render(<Avatar data-testid="avatar">SC</Avatar>);
+    const avatar = screen.getByTestId("avatar");
+
+    // Act & Assert
+    expect(avatar).toHaveTextContent("SC");
+  });
+
+  test("should renders in round shape", () => {
+    // Arrange
+    render(
+      <Avatar round data-testid="avatar">
+        SC
+      </Avatar>
+    );
+
+    //Act
+    const avatar = screen.getByTestId("avatar");
+    const result = isClassSuffixPresent(avatar, "round-true");
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  describe("with image", () => {
+    test("should renders with image", () => {
+      // Arrange
+      render(<Avatar src="user.png" data-testid="avatar" />);
+
+      //Act
+      const avatar = screen.getByTestId("avatar");
+      const img = within(avatar).getByRole("img");
+
+      // Assert
+      expect(img).toBeInTheDocument();
+    });
+
+    test("should have provided alt attribute", () => {
+      // Arrange
+      render(<Avatar alt="userpic" src="user.png" data-testid="avatar" />);
+
+      //Act
+      const avatar = screen.getByTestId("avatar");
+      const img = within(avatar).getByRole("img");
+
+      // Assert
+      expect(img).toHaveAttribute("alt", "userpic");
+    });
+  });
+
+  describe("with size", () => {
+    test("should renders with default size when size isn't present", () => {
+      // Arrange
+      render(<Avatar data-testid="avatar">SC</Avatar>);
+
+      //Act
+      const avatar = screen.getByTestId("avatar");
+      const result = isClassSuffixPresent(avatar, "size-sm");
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    type SizeType = "xs" | "sm" | "md" | "lg";
+    type SizeTestData = [size: SizeType, value: string];
+    const sizesToTest: SizeTestData[] = [
+      ["xs", "size-xs"],
+      ["sm", "size-sm"],
+      ["md", "size-md"],
+      ["lg", "size-lg"],
+    ];
+    test.each(sizesToTest)("should renders with %s size", (size, expected) => {
+      // Arrange
+      render(
+        <Avatar size={size} data-testid="avatar">
+          SC
+        </Avatar>
+      );
+
+      //Act
+      const avatar = screen.getByTestId("avatar");
+      const result = isClassSuffixPresent(avatar, expected);
+
+      // Assert
+      expect(result).toBe(true);
+    });
   });
 });

--- a/components/avatar/Avatart.test.tsx
+++ b/components/avatar/Avatart.test.tsx
@@ -109,6 +109,19 @@ describe("Avatar", () => {
     });
   });
 
+  describe("with status", () => {
+    test("should renders with status badge", () => {
+      // Arrange
+      render(<Avatar status={"online"} data-testid="avatar" />);
+
+      //Act
+      const badge = screen.getByTestId("status-badge");
+
+      // Assert
+      expect(badge).toBeInTheDocument();
+    });
+  });
+
   describe("with size", () => {
     test("should renders with default size when size isn't present", () => {
       // Arrange

--- a/components/avatar/README.md
+++ b/components/avatar/README.md
@@ -1,3 +1,122 @@
 # Avatar
 
-`Avatar` displays a profile picture or fallback.
+`Avatar` displays a profile picture, icon, or initials as text placeholder.
+
+## Placeholder
+
+Wrap text initials with `Avatar` component to render it as placeholder text.
+
+### Usage
+
+```jsx
+import { Avatar } from "spartak-ui";
+
+function App() {
+  return (
+    <Avatar>SC</Avatar>;
+  );
+}
+```
+
+## Icon
+
+There is `icon` property to use icon as placeholder.
+
+**NB:** `icon` property has a priority over placeholder text, if you use both, only one icon will be rendered.
+
+### Usage
+
+```jsx
+import { Avatar } from "spartak-ui";
+import { IconUser } from "@tabler/icons-react";
+
+function App() {
+  return (
+    <Avatar icon={<IconUser />} />
+  );
+}
+```
+
+## Image
+
+Pass an `URL` of an image to `src` property of `Avatar` component, to render this image.
+
+**NB:** Don't forget to add `alt` property with descriptive text for your image to make component accessible.
+
+### Usage
+
+```jsx
+import { Avatar } from "spartak-ui";
+
+function App() {
+  return (
+    <Avatar
+      src="userpic.png"
+      alt="User's profile picture"
+    />;
+  );
+}
+```
+
+## Round
+
+There is `round` property to make `Avatar` round shape.
+
+### Usage
+
+```jsx
+import { Avatar } from "spartak-ui";
+
+function App() {
+  return (
+    <Avatar round>SC</Avatar>;
+  );
+}
+```
+
+## Sizes
+
+There are four different sizes of `Avatar`:
+
+- `xs` – extra small avatar
+- `sm` (default) – small avatar
+- `md` – medium sized avatar
+- `lg` – large sized avatar
+
+If you don't specify `size` prop, the default size will be used.
+
+### Usage
+
+```jsx
+import { Avatar } from "spartak-ui";
+
+function App() {
+  return (
+    <Avatar size="lg">
+      LG
+    </Avatar>;
+  );
+}
+```
+
+## Status
+
+`status` prop will render a badge with status for `Avatar`. There are three different statuses:
+
+- `online` – `green` badge, to show that user is online
+- `offline` – `red` badge, to show that user is offline
+- `unread` – `blue` badge, to show that user has unread notifications or messages
+
+### Usage
+
+```jsx
+import { Avatar } from "spartak-ui";
+
+function App() {
+  return (
+    <Avatar status="online">
+      SC
+    </Avatar>;
+  );
+}
+```

--- a/components/avatar/README.md
+++ b/components/avatar/README.md
@@ -1,0 +1,3 @@
+# Avatar
+
+`Avatar` displays a profile picture or fallback.

--- a/components/avatar/README.md
+++ b/components/avatar/README.md
@@ -32,7 +32,7 @@ import { IconUser } from "@tabler/icons-react";
 
 function App() {
   return (
-    <Avatar icon={<IconUser />} />
+    <Avatar icon={<IconUser size="80%" />} />
   );
 }
 ```
@@ -70,6 +70,29 @@ import { Avatar } from "spartak-ui";
 function App() {
   return (
     <Avatar round>SC</Avatar>;
+  );
+}
+```
+
+## Colors
+
+There are several built-in `color` palettes available for `Avatar`:
+
+- `grey` (default)
+- `red`
+- `blue`
+- `green`
+
+If you don't specify `color` prop, the default variant will be used.
+
+### Usage
+
+```jsx
+import { Avatar } from "spartak-ui";
+
+function App() {
+  return (
+    <Avatar color="green">SC</Avatar>;
   );
 }
 ```

--- a/components/avatar/README.md
+++ b/components/avatar/README.md
@@ -104,7 +104,8 @@ function App() {
 `status` prop will render a badge with status for `Avatar`. There are three different statuses:
 
 - `online` – `green` badge, to show that user is online
-- `offline` – `red` badge, to show that user is offline
+- `busy` – `red` badge, to show that user is busy (do not disturb)
+- `offline` – `grey` badge, to show that user is offline
 - `unread` – `blue` badge, to show that user has unread notifications or messages
 
 ### Usage

--- a/components/avatar/index.ts
+++ b/components/avatar/index.ts
@@ -1,0 +1,1 @@
+export { Avatar } from "./Avatar";

--- a/components/avatar/stories/Avatar.stories.tsx
+++ b/components/avatar/stories/Avatar.stories.tsx
@@ -23,6 +23,10 @@ export default {
       options: [true, false],
       control: { type: "radio" },
     },
+    color: {
+      options: ["grey", "red", "blue", "green"],
+      control: { type: "radio" },
+    },
     status: {
       options: ["online", "busy", "offline", "unread", undefined],
       control: { type: "radio" },
@@ -38,16 +42,20 @@ const Default = Template.bind({});
 Default.args = {
   size: "sm",
   round: false,
-};
-
-export const Empty = Template.bind({});
-Empty.args = {
-  ...Default.args,
+  color: "grey",
 };
 
 export const Placeholder = Template.bind({});
 Placeholder.args = {
   ...Default.args,
+  children: "SC",
+};
+
+
+export const Colors = Template.bind({});
+Colors.args = {
+  ...Default.args,
+  color: "green",
   children: "SC",
 };
 

--- a/components/avatar/stories/Avatar.stories.tsx
+++ b/components/avatar/stories/Avatar.stories.tsx
@@ -24,7 +24,7 @@ export default {
       control: { type: "radio" },
     },
     status: {
-      options: ["online", "offline", "unread", undefined],
+      options: ["online", "busy", "offline", "unread", undefined],
       control: { type: "radio" },
     },
   },

--- a/components/avatar/stories/Avatar.stories.tsx
+++ b/components/avatar/stories/Avatar.stories.tsx
@@ -21,6 +21,11 @@ export default {
     },
     round: {
       options: [true, false],
+      control: { type: "radio" },
+    },
+    status: {
+      options: ["online", "offline", "unread", undefined],
+      control: { type: "radio" },
     },
   },
 } as ComponentMeta<typeof Avatar>;
@@ -72,4 +77,11 @@ export const Icon = Template.bind({});
 Icon.args = {
   ...Default.args,
   icon: <IconUser stroke={2} size="80%" />,
+};
+
+export const Status = Template.bind({});
+Status.args = {
+  ...Default.args,
+  children: "SC",
+  status: "online",
 };

--- a/components/avatar/stories/Avatar.stories.tsx
+++ b/components/avatar/stories/Avatar.stories.tsx
@@ -1,0 +1,25 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
+import { Avatar } from "../Avatar";
+
+export default {
+  title: "Components/Avatar",
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
+  component: Avatar,
+  argTypes: {},
+} as ComponentMeta<typeof Avatar>;
+
+const Template: ComponentStory<typeof Avatar> = (props) => (
+  <Avatar {...props} />
+);
+
+export const Default = Template.bind({});
+
+Default.args = {};

--- a/components/avatar/stories/Avatar.stories.tsx
+++ b/components/avatar/stories/Avatar.stories.tsx
@@ -13,13 +13,52 @@ export default {
     ),
   ],
   component: Avatar,
-  argTypes: {},
+  argTypes: {
+    size: {
+      options: ["xs", "sm", "md", "lg"],
+      control: { type: "radio" },
+    },
+  },
 } as ComponentMeta<typeof Avatar>;
 
-const Template: ComponentStory<typeof Avatar> = (props) => (
-  <Avatar {...props} />
+const Template: ComponentStory<typeof Avatar> = ({ children, ...props }) => (
+  <Avatar {...props}>{children}</Avatar>
 );
 
-export const Default = Template.bind({});
+const Default = Template.bind({});
+Default.args = {
+  size: "sm",
+};
 
-Default.args = {};
+export const Empty = Template.bind({});
+Empty.args = {
+  ...Default.args,
+};
+
+export const Placeholder = Template.bind({});
+Placeholder.args = {
+  ...Default.args,
+  children: "SC",
+};
+
+export const Round = Template.bind({});
+Round.args = {
+  ...Default.args,
+  round: true,
+  children: "SC",
+};
+
+export const Image = Template.bind({});
+Image.args = {
+  ...Default.args,
+  src: "https://avatars.githubusercontent.com/u/1219618",
+  alt: "Sergei Cherniaev",
+};
+
+export const RoundWithImage = Template.bind({});
+RoundWithImage.args = {
+  ...Default.args,
+  round: true,
+  src: "https://avatars.githubusercontent.com/u/1219618",
+  alt: "Sergei Cherniaev",
+};

--- a/components/avatar/stories/Avatar.stories.tsx
+++ b/components/avatar/stories/Avatar.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { useDarkMode } from "storybook-dark-mode";
 import { darkTheme } from "../../stitches.config";
 import { Avatar } from "../Avatar";
+import { IconUser } from "@tabler/icons-react";
 
 export default {
   title: "Components/Avatar",
@@ -18,6 +19,9 @@ export default {
       options: ["xs", "sm", "md", "lg"],
       control: { type: "radio" },
     },
+    round: {
+      options: [true, false],
+    },
   },
 } as ComponentMeta<typeof Avatar>;
 
@@ -28,6 +32,7 @@ const Template: ComponentStory<typeof Avatar> = ({ children, ...props }) => (
 const Default = Template.bind({});
 Default.args = {
   size: "sm",
+  round: false,
 };
 
 export const Empty = Template.bind({});
@@ -61,4 +66,10 @@ RoundWithImage.args = {
   round: true,
   src: "https://avatars.githubusercontent.com/u/1219618",
   alt: "Sergei Cherniaev",
+};
+
+export const Icon = Template.bind({});
+Icon.args = {
+  ...Default.args,
+  icon: <IconUser stroke={2} size="80%" />,
 };

--- a/components/button/Button.test.tsx
+++ b/components/button/Button.test.tsx
@@ -141,10 +141,11 @@ describe("Button", () => {
       expect(result).toBe(true);
     });
 
-    type ColorType = "red" | "blue";
+    type ColorType = "red"| "green" | "blue";
     type ColorTestData = [color: ColorType, value: string];
     const colorsToTest: ColorTestData[] = [
       ["red", "color-red"],
+      ["green", "color-green"],
       ["blue", "color-blue"],
     ];
     test.each(colorsToTest)(

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./avatar";
 export * from "./button";
 export * from "./card";
 export * from "./code";

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -175,6 +175,7 @@ export const { theme, styled, globalCss } = createStitches({
     borderWidths: {
       1: "1px",
       2: "2px",
+      3: "3px",
     },
     borderStyles: {},
     radii: {


### PR DESCRIPTION
Add the `Avatar` component to display a profile picture, icon, or placeholder.

**`Avatar` props API**

- [x] `size`: `xs`, `sm` (default), `md`, `lg` – avatar icon in different sizes
- [x] `src` – link to the source of an image (priority is higher than `icon`)
- [x] `icon` – to provide an icon as an alternative to the image  (priority is lower than `src`)
- [x] `round`: `boolean` – to make it round
- [x] `status`: `online`, `busy`, `offline`, `unread` – to show status
- [x] `colors`:  `grey` (default), `red`, `green`, `blue` – the color of the fallback avatar 

Resolves #47 

---

- [x] I wrote corresponding tests for the features
- [x] I updated docs with examples of `Avatar` usage.

***This is work in progress pull request, API may change.***