### PR TITLE
feat(badge): add `Badge` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A collection of React components
 **Display content**
 
 - [Avatar](https://github.com/shdq/spartak-ui/tree/main/components/avatar#avatar)
+- [Badge](https://github.com/shdq/spartak-ui/tree/main/components/badge#badge)
 - [Card](https://github.com/shdq/spartak-ui/tree/main/components/card#card)
 
 Check out [Storybook](https://shdq.github.io/spartak-ui/) for visual look of the components.

--- a/components/badge/Badge.test.tsx
+++ b/components/badge/Badge.test.tsx
@@ -48,6 +48,42 @@ describe("Badge", () => {
     expect(badge).toHaveAttribute("href", "https://example.com");
   });
 
+  describe("with variant", () => {
+    test("should renders with default variant when variant isn't present", () => {
+      // Arrange
+      render(<Badge>Tests</Badge>);
+
+      // Act
+      const badge = screen.getByText("Tests");
+      const result = isClassSuffixPresent(badge, "variant-filled");
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    type VarianType = "filled" | "tinted" | "outlined";
+    type VariantTestData = [variant: VarianType, value: string];
+    const variantsToTest: VariantTestData[] = [
+      ["filled", "variant-filled"],
+      ["tinted", "variant-tinted"],
+      ["outlined", "variant-outlined"],
+    ];
+    test.each(variantsToTest)(
+      "should renders with %s variant",
+      (variant, expected) => {
+        // Arrange
+        render(<Badge variant={variant}>Tests</Badge>);
+
+        // Act
+        const badge = screen.getByText("Tests");
+        const result = isClassSuffixPresent(badge, expected);
+
+        // Assert
+        expect(result).toBe(true);
+      }
+    );
+  });
+
   describe("with color", () => {
     test("should renders with default color", () => {
       // Arrange
@@ -55,16 +91,15 @@ describe("Badge", () => {
 
       // Act
       const badge = screen.getByText("Tests");
-      const result = isClassSuffixPresent(badge, "color-grey");
+      const result = isClassSuffixPresent(badge, "color-red");
 
       // Assert
       expect(result).toBe(true);
     });
 
-    type ColorType = "grey" | "red" | "green" | "blue";
+    type ColorType = "red" | "green" | "blue";
     type ColorTestData = [color: ColorType, value: string];
     const colorsToTest: ColorTestData[] = [
-      ["grey", "color-grey"],
       ["red", "color-red"],
       ["green", "color-green"],
       ["blue", "color-blue"],

--- a/components/badge/Badge.test.tsx
+++ b/components/badge/Badge.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { Badge } from "./Badge";
+
+describe("Badge", () => {
+  test("should renders", () => {
+    // Arrange
+    render(<Badge>Tests</Badge>);
+
+    // Act
+    const badge = screen.getByText("Tests");
+
+    // Assert
+    expect(badge).toBeInTheDocument();
+  });
+});

--- a/components/badge/Badge.test.tsx
+++ b/components/badge/Badge.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { Badge } from "./Badge";
 
+const isClassSuffixPresent = (element: HTMLElement, value: string): boolean => {
+  return [...element.classList].some((className) => className.endsWith(value));
+};
+
 describe("Badge", () => {
   test("should renders", () => {
     // Arrange
@@ -11,5 +15,73 @@ describe("Badge", () => {
 
     // Assert
     expect(badge).toBeInTheDocument();
+  });
+
+  test("should renders as <span>", () => {
+    // Arrange
+    render(<Badge>Tests</Badge>);
+
+    // Act
+    const badge = screen.getByText((text, element) => {
+      return element?.tagName.toLowerCase() === "span" && text === "Tests";
+    });
+
+    // Assert
+    expect(badge).toBeInTheDocument();
+  });
+
+  test("should renders as link", () => {
+    // Arrange
+    render(
+      <Badge as="a" href="https://example.com" target="_blank">
+        Tests
+      </Badge>
+    );
+
+    // Act
+    const badge = screen.getByText((text, element) => {
+      return element?.tagName.toLowerCase() === "a" && text === "Tests";
+    });
+
+    // Assert
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("href", "https://example.com");
+  });
+
+  describe("with color", () => {
+    test("should renders with default color", () => {
+      // Arrange
+      render(<Badge>Tests</Badge>);
+
+      // Act
+      const badge = screen.getByText("Tests");
+      const result = isClassSuffixPresent(badge, "color-grey");
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    type ColorType = "grey" | "red" | "green" | "blue";
+    type ColorTestData = [color: ColorType, value: string];
+    const colorsToTest: ColorTestData[] = [
+      ["grey", "color-grey"],
+      ["red", "color-red"],
+      ["green", "color-green"],
+      ["blue", "color-blue"],
+    ];
+    test.each(colorsToTest)(
+      "should renders with %s color",
+      (color, expected) => {
+        // Arrange
+        render(<Badge color={color}>Tests</Badge>);
+
+        // Act
+        const badge = screen.getByText("Tests");
+        const result = isClassSuffixPresent(badge, expected);
+
+        // Assert
+        expect(result).toBe(true);
+      }
+    );
   });
 });

--- a/components/badge/Badge.test.tsx
+++ b/components/badge/Badge.test.tsx
@@ -84,4 +84,38 @@ describe("Badge", () => {
       }
     );
   });
+
+  describe("with size", () => {
+    test("should renders with default size", () => {
+      // Arrange
+      render(<Badge>Tests</Badge>);
+
+      // Act
+      const badge = screen.getByText("Tests");
+      const result = isClassSuffixPresent(badge, "size-sm");
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    type SizeType = "xs" | "sm" | "md" | "lg";
+    type SizeTestData = [size: SizeType, value: string];
+    const sizesToTest: SizeTestData[] = [
+      ["xs", "size-xs"],
+      ["sm", "size-sm"],
+      ["md", "size-md"],
+      ["lg", "size-lg"],
+    ];
+    test.each(sizesToTest)("should renders with %s size", (size, expected) => {
+      // Arrange
+      render(<Badge size={size}>Tests</Badge>);
+
+      // Act
+      const badge = screen.getByText("Tests");
+      const result = isClassSuffixPresent(badge, expected);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -1,3 +1,42 @@
 import { styled } from "../stitches.config";
 
-export const Badge = styled("span", {});
+export const Badge = styled("span", {
+  fontFamily: "$system",
+  border: "$borderWidths$1 solid transparent",
+  borderRadius: "2em",
+  fontSize: "0.8em",
+  padding: ".2em .5em",
+  userSelect: "none",
+  display: "inline-flex",
+  alignItems: "center",
+  whiteSpace: "nowrap",
+  textDecoration: "none",
+
+  variants: {
+    color: {
+      grey: {
+        color: "$grey700",
+        backgroundColor: "$grey400",
+        borderColor: "$$grey700",
+      },
+      red: {
+        color: "$red400",
+        backgroundColor: "$red000",
+        borderColor: "$$red400",
+      },
+      green: {
+        color: "$green400",
+        backgroundColor: "$green000",
+        borderColor: "$$green400",
+      },
+      blue: {
+        color: "$blue400",
+        backgroundColor: "$blue000",
+        borderColor: "$$blue400",
+      },
+    },
+  },
+  defaultVariants: {
+    color: "grey",
+  },
+});

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -3,13 +3,14 @@ import { styled } from "../stitches.config";
 export const Badge = styled("span", {
   fontFamily: "$system",
   border: "$borderWidths$1 solid transparent",
-  borderRadius: "2em",
-  fontSize: "0.8em",
-  padding: ".2em .5em",
-  userSelect: "none",
-  display: "inline-flex",
-  alignItems: "center",
+  borderRadius: "$round",
+  padding: ".2em .4em",
+  display: "inline-block",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
   whiteSpace: "nowrap",
+  textAlign: "center",
+  userSelect: "none",
   textDecoration: "none",
 
   variants: {
@@ -35,8 +36,23 @@ export const Badge = styled("span", {
         borderColor: "$$blue400",
       },
     },
+    size: {
+      xs: {
+        fontSize: "$xxs",
+      },
+      sm: {
+        fontSize: "$xs",
+      },
+      md: {
+        fontSize: "$sm",
+      },
+      lg: {
+        fontSize: "$md",
+      },
+    },
   },
   defaultVariants: {
     color: "grey",
+    size: "sm",
   },
 });

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -17,25 +17,41 @@ export const Badge = styled("span", {
 
   variants: {
     color: {
-      grey: {
-        color: "$grey700",
-        backgroundColor: "$grey400",
-        borderColor: "$$grey700",
-      },
       red: {
-        color: "$red400",
-        backgroundColor: "$red000",
-        borderColor: "$$red400",
-      },
-      green: {
-        color: "$green400",
-        backgroundColor: "$green000",
-        borderColor: "$$green400",
+        $$color000: "$colors$red000",
+        $$color100: "$colors$red100",
+        $$color400: "$colors$red400",
+        $$color500: "$colors$red500",
+        $$color600: "$colors$red600",
       },
       blue: {
-        color: "$blue400",
-        backgroundColor: "$blue000",
-        borderColor: "$$blue400",
+        $$color000: "$colors$blue000",
+        $$color100: "$colors$blue100",
+        $$color400: "$colors$blue400",
+        $$color500: "$colors$blue500",
+        $$color600: "$colors$blue600",
+      },
+      green: {
+        $$color000: "$colors$green000",
+        $$color100: "$colors$green100",
+        $$color400: "$colors$green400",
+        $$color500: "$colors$green500",
+        $$color600: "$colors$green600",
+      },
+    },
+    variant: {
+      filled: {
+        color: "$white",
+        backgroundColor: "$$color500",
+      },
+      tinted: {
+        color: "$$color400",
+        backgroundColor: "$$color000",
+        borderColor: "$$color400",
+      },
+      outlined: {
+        color: "$$color400",
+        borderColor: "$$color400",
       },
     },
     size: {
@@ -54,7 +70,8 @@ export const Badge = styled("span", {
     },
   },
   defaultVariants: {
-    color: "grey",
+    variant: "filled",
+    color: "red",
     size: "sm",
   },
 });

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -1,0 +1,3 @@
+import { styled } from "../stitches.config";
+
+export const Badge = styled("span", {});

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -2,10 +2,12 @@ import { styled } from "../stitches.config";
 
 export const Badge = styled("span", {
   fontFamily: "$system",
+  fontWeight: "$medium",
   border: "$borderWidths$1 solid transparent",
   borderRadius: "$round",
   padding: ".2em .4em",
   display: "inline-block",
+  verticalAlign: "middle",
   overflow: "hidden",
   textOverflow: "ellipsis",
   whiteSpace: "nowrap",

--- a/components/badge/README.md
+++ b/components/badge/README.md
@@ -1,0 +1,3 @@
+# Badge
+
+`Badge` displays badges, tags, highlights something

--- a/components/badge/README.md
+++ b/components/badge/README.md
@@ -1,3 +1,121 @@
 # Badge
 
 `Badge` displays badges, tags, highlights something
+
+### Usage
+
+```jsx
+import { Badge } from "spartak-ui";
+
+function App() {
+  return (
+    <Badge>good first issue</Badge>;
+  );
+}
+```
+
+## Variants
+
+There are three different styles of `Badge`:
+
+- `filled` (default)
+- `tinted`
+- `outlined`
+
+If you don't specify `variant` prop, the default variant will be used.
+
+### Usage
+
+```jsx
+import { Badge } from "spartak-ui";
+
+function App() {
+  return (
+    <Badge variant="outlined">
+      Outlined
+    </Badge>;
+  );
+}
+```
+
+## Colors
+
+There are several built-in `color` palettes available for `Badge`:
+
+- `red` (default)
+- `blue`
+- `green`
+
+If you don't specify `color` prop, the default variant will be used.
+
+### Usage
+
+```jsx
+import { Badge } from "spartak-ui";
+
+function App() {
+  return (
+    <Badge color="blue">
+      Blue
+    </Badge>;
+  );
+}
+```
+
+## Sizes
+
+There are four different sizes of `Badge`:
+
+- `xs` – extra small
+- `sm` (default) – small
+- `md` – medium
+- `lg` – large
+
+If you don't specify `size` prop, the default size will be used.
+
+### Usage
+
+```jsx
+import { Badge } from "spartak-ui";
+
+function App() {
+  return (
+    <Badge size="lg">
+      Large
+    </Badge>;
+  );
+}
+```
+
+## Badge as a link
+
+Provide HTML element name `a` to `as` property and `href` with path or URL to render `Badge` component as a link.
+
+### Usage
+
+```jsx
+import { Badge } from "spartak-ui";
+
+function App() {
+  return (
+    <Badge
+      as="a"
+      href="https://example.com"
+    >
+      Click on me
+    </Badge>
+  );
+}
+```
+
+## Combined style
+
+You can combine variants. The example below will render a blue, tinted badge.
+
+### Usage
+
+```jsx
+<Badge variant="tinted" color="blue">
+  Combined style
+</Badge>
+```

--- a/components/badge/index.ts
+++ b/components/badge/index.ts
@@ -1,0 +1,1 @@
+export { Badge } from "./Badge";

--- a/components/badge/stories/Badge.stories.tsx
+++ b/components/badge/stories/Badge.stories.tsx
@@ -5,7 +5,7 @@ import { darkTheme } from "../../stitches.config";
 import { Badge } from "../../index";
 
 const BadgeMeta: ComponentMeta<typeof Badge> = {
-  title: "Components/Typography/Badge",
+  title: "Components/Badge",
   decorators: [
     (Story) => (
       <div className={useDarkMode() ? darkTheme.className : undefined}>

--- a/components/badge/stories/Badge.stories.tsx
+++ b/components/badge/stories/Badge.stories.tsx
@@ -15,8 +15,12 @@ const BadgeMeta: ComponentMeta<typeof Badge> = {
   ],
   component: Badge,
   argTypes: {
+    variant: {
+      options: ["filled", "tinted", "outlined"],
+      control: { type: "radio" },
+    },
     color: {
-      options: ["grey", "red", "blue", "green"],
+      options: ["red", "blue", "green"],
       control: { type: "radio" },
     },
     size: {
@@ -33,27 +37,36 @@ const Template: ComponentStory<typeof Badge> = ({
 
 const Default = Template.bind({});
 Default.args = {
-  children: "good first issue",
-  color: "grey",
+  children: 42,
+  variant: "filled",
+  color: "red",
   size: "sm",
 };
 
-export const Example = Template.bind({});
-Example.args = {
+export const Colors = Template.bind({});
+Colors.args = {
   ...Default.args,
 };
 
-export const Number = Template.bind({});
-Number.args = {
+export const Variants = Template.bind({});
+Variants.args = {
   ...Default.args,
-  color: "blue",
-  children: 42,
+  variant: "tinted",
+  color: "green",
+  children: "good first issue",
+};
+
+export const Sizes = Template.bind({});
+Sizes.args = {
+  ...Default.args,
+  size: "lg",
+  children: "WARNING",
 };
 
 export const TextOverflow = Template.bind({});
 TextOverflow.args = {
   ...Default.args,
-  color: "red",
+  color: "blue",
   size: "xs",
   css: { width: "100px" },
   children: "Change badge size",

--- a/components/badge/stories/Badge.stories.tsx
+++ b/components/badge/stories/Badge.stories.tsx
@@ -16,7 +16,7 @@ const BadgeMeta: ComponentMeta<typeof Badge> = {
   component: Badge,
   argTypes: {
     color: {
-      options: ["red", "blue", "green"],
+      options: ["grey", "red", "blue", "green"],
       control: { type: "radio" },
     },
   },
@@ -30,11 +30,19 @@ const Template: ComponentStory<typeof Badge> = ({
 const Default = Template.bind({});
 Default.args = {
   children: "good first issue",
+  color: "grey",
 };
 
 export const Example = Template.bind({});
 Example.args = {
   ...Default.args,
+};
+
+export const Number = Template.bind({});
+Number.args = {
+  ...Default.args,
+  color: "blue",
+  children: 42,
 };
 
 export default BadgeMeta;

--- a/components/badge/stories/Badge.stories.tsx
+++ b/components/badge/stories/Badge.stories.tsx
@@ -19,6 +19,10 @@ const BadgeMeta: ComponentMeta<typeof Badge> = {
       options: ["grey", "red", "blue", "green"],
       control: { type: "radio" },
     },
+    size: {
+      options: ["xs", "sm", "md", "lg"],
+      control: { type: "radio" },
+    },
   },
 };
 
@@ -31,6 +35,7 @@ const Default = Template.bind({});
 Default.args = {
   children: "good first issue",
   color: "grey",
+  size: "sm",
 };
 
 export const Example = Template.bind({});
@@ -43,6 +48,15 @@ Number.args = {
   ...Default.args,
   color: "blue",
   children: 42,
+};
+
+export const TextOverflow = Template.bind({});
+TextOverflow.args = {
+  ...Default.args,
+  color: "red",
+  size: "xs",
+  css: { width: "100px" },
+  children: "Change badge size",
 };
 
 export default BadgeMeta;

--- a/components/badge/stories/Badge.stories.tsx
+++ b/components/badge/stories/Badge.stories.tsx
@@ -1,0 +1,40 @@
+import { type PropsWithChildren } from "react";
+import { type ComponentStory, type ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
+import { Badge } from "../../index";
+
+const BadgeMeta: ComponentMeta<typeof Badge> = {
+  title: "Components/Typography/Badge",
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
+  component: Badge,
+  argTypes: {
+    color: {
+      options: ["red", "blue", "green"],
+      control: { type: "radio" },
+    },
+  },
+};
+
+const Template: ComponentStory<typeof Badge> = ({
+  children,
+  ...args
+}: PropsWithChildren) => <Badge {...args}>{children}</Badge>;
+
+const Default = Template.bind({});
+Default.args = {
+  children: "good first issue",
+};
+
+export const Example = Template.bind({});
+Example.args = {
+  ...Default.args,
+};
+
+export default BadgeMeta;

--- a/components/heading/stories/Heading.stories.tsx
+++ b/components/heading/stories/Heading.stories.tsx
@@ -2,7 +2,7 @@ import { type PropsWithChildren } from "react";
 import { type ComponentStory, type ComponentMeta } from "@storybook/react";
 import { useDarkMode } from "storybook-dark-mode";
 import { darkTheme } from "../../stitches.config";
-import { Heading, Text } from "../../index";
+import { Heading, Text, Badge } from "../../index";
 
 const HeadingMeta: ComponentMeta<typeof Heading> = {
   title: "Components/Typography/Heading",
@@ -72,6 +72,17 @@ WithLink.args = {
     </>
   ),
   size: "xl",
+};
+
+export const WithBadge = Template.bind({});
+WithBadge.args = {
+  ...Default.args,
+  size: "sm",
+  children: (
+    <>
+      Heading component <Badge color="green">New</Badge>
+    </>
+  ),
 };
 
 export default HeadingMeta;

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./avatar";
+export * from "./badge";
 export * from "./button";
 export * from "./card";
 export * from "./code";

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -180,6 +180,7 @@ export const { theme, styled, globalCss } = createStitches({
     borderStyles: {},
     radii: {
       3: "3px",
+      round: "9999px",
     },
     shadows: {
       boxShadow: "rgba(0, 0, 0, 0.24) 0px 1px 4px",

--- a/components/stitches.config.ts
+++ b/components/stitches.config.ts
@@ -162,6 +162,7 @@ export const { theme, styled, globalCss } = createStitches({
     },
     fontWeights: {
       normal: 400,
+      medium: 500,
       bold: 600,
     },
     lineHeights: {},

--- a/components/text/stories/Text.stories.tsx
+++ b/components/text/stories/Text.stories.tsx
@@ -2,7 +2,7 @@ import { type PropsWithChildren } from "react";
 import { type ComponentStory, type ComponentMeta } from "@storybook/react";
 import { useDarkMode } from "storybook-dark-mode";
 import { darkTheme } from "../../stitches.config";
-import { Text } from "../Text";
+import { Badge, Text } from "../../index";
 
 const TextMeta: ComponentMeta<typeof Text> = {
   title: "Components/Typography/Text",
@@ -97,6 +97,20 @@ AsOtherElements.args = {
         </Text>
         O
       </Text>
+    </>
+  ),
+};
+
+export const WithBadge = Template.bind({});
+WithBadge.args = {
+  ...Default.args,
+  size: "sm",
+  children: (
+    <>
+      Messages{" "}
+      <Badge color="blue" size="xs">
+        99+
+      </Badge>
     </>
   ),
 };


### PR DESCRIPTION
**Description**

This PR added `Badge` component to display badges, tags, highlight something

### Usage

```jsx
import { Badge } from "spartak-ui";

function App() {
  return (
    <Badge>
      good first issue
    </Badge>;
  );
}
```

This example renders in HTML as inline `span`:

```html
<span>good first issue</code>
```

**`Badge` props API:**

- [x] `color`: `red` (default), `green`, `blue`
- [x] `size`: `xs`, `sm` (default), `md`, `lg`
- [x]  `variants`: `filled` (default), `tinted`, `outlined`

---

- [x] I wrote corresponding tests for the features
- [ ] I updated the docs with descriptions and code samples

Resolves #53 

***This is work in progress PR, API may change.***