### PR TITLE
fix(themeProvider): add check for "typeof window" is not undefined

### DIFF
--- a/components/provider/ThemeProvider.tsx
+++ b/components/provider/ThemeProvider.tsx
@@ -27,8 +27,10 @@ const ThemeContext = createContext<ThemeContextType | null>(null);
 export const ThemeProvider = ({ children }: PropsWithChildren): JSX.Element => {
   const [themeMode, setThemeMode] = useState<Theme>("light");
   let html: HTMLElement;
-  useEffect(() => {
+  if (typeof window !== "undefined") {
     html = document.documentElement;
+  }
+  useEffect(() => {
     const defaultTheme =
       localStorage["spartak-ui-theme"] !== undefined
         ? localStorage.getItem("spartak-ui-theme")


### PR DESCRIPTION
**Description**

This PR fixes the changes introduced in the previous PR #63 

Instead of putting it in `useState`, perform the check for `window` existence:

```typescript
if (typeof window !== "undefined") {
    // usage of document
}
```

Part of Issue #62 