### PR TITLE
chore(ci): update `publish to npm` workflow to add provenance (digital signature)

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+     id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,6 +27,6 @@ jobs:
       - name: Build package
         run: npm run build
       - name: Publish package
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
GitHub has npm provenance in public beta to improve security for packages published to NPM ([blog post](https://github.blog/changelog/2023-04-19-npm-provenance-public-beta/))

This PR updated the current `Publish to NPM` workflow and added provenance to Spartak UI.

It will add similar section on NPM registry page

![image](https://user-images.githubusercontent.com/1219618/236673351-ad6ad2c0-5f5e-495e-8fd6-db676954193c.png)

This `npm audit signatures` allow you to verify npm package integrity ([blog post](https://github.blog/changelog/2022-07-26-a-new-npm-audit-signatures-command-to-verify-npm-package-integrity/))

Part of #61 