### PR TITLE
docs(examples): switch to storybook theme toggle button for UI examples

### DIFF
--- a/components/examples/Spotify/App.tsx
+++ b/components/examples/Spotify/App.tsx
@@ -1,15 +1,6 @@
-import {
-  ThemeProvider,
-  Button,
-  Heading,
-  Text,
-  Card,
-  CardHeader,
-  CardBody,
-} from "../../index";
+import { Button, Heading, Text, Card, CardHeader, CardBody } from "../../index";
 import { styled } from "../../stitches.config";
 import { IconPlayerPlayFilled } from "@tabler/icons-react";
-import { Switch } from "../../provider/Switch";
 
 type Colors = "red" | "blue" | "green";
 type Variants = "filled" | "outlined" | "elevated";
@@ -118,12 +109,7 @@ const App = ({ color, variant }: AppProps): JSX.Element => {
     );
   });
 
-  return (
-    <ThemeProvider>
-      <Switch color={color} />
-      <Div>{cards}</Div>
-    </ThemeProvider>
-  );
+  return <Div>{cards}</Div>;
 };
 
 export default App;

--- a/components/examples/Twitter/App.tsx
+++ b/components/examples/Twitter/App.tsx
@@ -1,5 +1,4 @@
 import {
-  ThemeProvider,
   Avatar,
   Button,
   Heading,
@@ -9,7 +8,6 @@ import {
   CardBody,
   CardFooter,
 } from "../../index";
-import { Switch } from "../../provider/Switch";
 
 type Colors = "red" | "blue" | "green";
 type Variants = "filled" | "outlined" | "elevated";
@@ -20,66 +18,63 @@ export interface AppProps {
 
 const App = ({ color, variant }: AppProps): JSX.Element => {
   return (
-    <ThemeProvider>
-      <Switch color={color} />
-      <Card css={{ marginTop: "15px", width: "250px" }} variant={variant}>
-        <CardHeader css={{ display: "flex", justifyContent: "space-between" }}>
-          <Avatar
-            src="https://pbs.twimg.com/profile_images/1447920585506496521/RgBsNyEO_400x400.jpg"
-            round
-            size="lg"
-          >
-            SC
-          </Avatar>
-          <Button
+    <Card css={{ marginTop: "15px", width: "250px" }} variant={variant}>
+      <CardHeader css={{ display: "flex", justifyContent: "space-between" }}>
+        <Avatar
+          src="https://pbs.twimg.com/profile_images/1447920585506496521/RgBsNyEO_400x400.jpg"
+          round
+          size="lg"
+        >
+          SC
+        </Avatar>
+        <Button
+          as="a"
+          href="https://twitter.com/shdq"
+          variant="filled"
+          color={color}
+        >
+          Follow
+        </Button>
+      </CardHeader>
+      <CardBody
+        css={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "10px",
+          paddingBottom: "15px",
+        }}
+      >
+        <div>
+          <Heading size="sm">Sergei Cherniaev </Heading>
+          <Text size="sm" secondary>
+            @shdq
+          </Text>
+        </div>
+        <Text size="sm">
+          Software Engineer (front-end). Father of a son. I&apos;m building{" "}
+          <Text
             as="a"
-            href="https://twitter.com/shdq"
-            variant="filled"
+            href="https://github.com/shdq/spartak-ui"
+            target="_blank"
             color={color}
           >
-            Follow
-          </Button>
-        </CardHeader>
-        <CardBody
-          css={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "10px",
-            paddingBottom: "15px",
-          }}
-        >
-          <div>
-            <Heading size="sm">Sergei Cherniaev </Heading>
-            <Text size="sm" secondary>
-              @shdq
-            </Text>
-          </div>
-          <Text size="sm">
-            Software Engineer (front-end). Father of a son. I&apos;m building{" "}
-            <Text
-              as="a"
-              href="https://github.com/shdq/spartak-ui"
-              target="_blank"
-              color={color}
-            >
-              @SpartakUI
-            </Text>
+            @SpartakUI
           </Text>
-        </CardBody>
-        <CardFooter>
-          <Text size="sm">
-            <strong>98</strong>{" "}
-            <Text as="span" secondary>
-              Following
-            </Text>{" "}
-            <strong>209</strong>{" "}
-            <Text as="span" secondary>
-              Followers
-            </Text>
+        </Text>
+      </CardBody>
+      <CardFooter>
+        <Text size="sm">
+          <strong>98</strong>{" "}
+          <Text as="span" secondary>
+            Following
+          </Text>{" "}
+          <strong>209</strong>{" "}
+          <Text as="span" secondary>
+            Followers
           </Text>
-        </CardFooter>
-      </Card>
-    </ThemeProvider>
+        </Text>
+      </CardFooter>
+    </Card>
   );
 };
 

--- a/components/examples/YouTube/App.tsx
+++ b/components/examples/YouTube/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useTheme, ThemeProvider, Button } from "../../index";
-import { Switch } from "../../provider/Switch";
+import { Button } from "../../index";
+import { useDarkMode } from "storybook-dark-mode";
 import {
   IconMenu2,
   IconHome,
@@ -20,13 +20,12 @@ interface HeaderProps {
 }
 
 const Header = ({ color }: HeaderProps): JSX.Element => {
-  const { theme } = useTheme();
-  const isThemeDark = theme === "dark";
+  const isThemeDark = useDarkMode();
   const logoColor = isThemeDark ? "white" : "black";
 
   const headerStyles: React.CSSProperties = {
     display: "flex",
-    justifyContent: "space-between",
+    justifyContent: "start",
     alignItems: "center",
     gap: "15px",
     marginBottom: "20px",
@@ -65,7 +64,6 @@ const Header = ({ color }: HeaderProps): JSX.Element => {
           </g>
         </g>
       </svg>
-      <Switch color={color} />
     </div>
   );
 };
@@ -134,11 +132,7 @@ export interface AppProps {
 }
 
 const App = ({ color, size }: AppProps): JSX.Element => {
-  return (
-    <ThemeProvider>
-      <SideMenu color={color} size={size} />
-    </ThemeProvider>
-  );
+  return <SideMenu color={color} size={size} />;
 };
 
 export default App;

--- a/components/examples/stories/Spotify.stories.tsx
+++ b/components/examples/stories/Spotify.stories.tsx
@@ -1,8 +1,17 @@
 import { type ComponentStory, type ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
 import App from "../Spotify/App";
 
 const SpotifyMeta: ComponentMeta<typeof App> = {
   title: "UI Showcase",
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     variant: {
       options: ["filled", "outlined", "elevated"],

--- a/components/examples/stories/Twitter.stories.tsx
+++ b/components/examples/stories/Twitter.stories.tsx
@@ -1,8 +1,17 @@
 import { type ComponentStory, type ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
 import App from "../Twitter/App";
 
 const TwitterMeta: ComponentMeta<typeof App> = {
   title: "UI Showcase",
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     variant: {
       options: ["filled", "outlined", "elevated"],

--- a/components/examples/stories/YouTube.stories.tsx
+++ b/components/examples/stories/YouTube.stories.tsx
@@ -1,8 +1,17 @@
 import { type ComponentStory, type ComponentMeta } from "@storybook/react";
+import { useDarkMode } from "storybook-dark-mode";
+import { darkTheme } from "../../stitches.config";
 import App from "../YouTube/App";
 
 const YouTubeMeta: ComponentMeta<typeof App> = {
   title: "UI Showcase",
+  decorators: [
+    (Story) => (
+      <div className={useDarkMode() ? darkTheme.className : undefined}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     size: {
       options: ["xs", "sm", "md", "lg"],


### PR DESCRIPTION
**Description**

This PR added support for `storybook` theme toggle button to UI Showcase examples.

Before this change, examples used `Spartak UI` `Switch` component, which doesn't work together with `Storybook` theme toggle button.

Improvement related to #26 

