### PR TITLE
fix(text): fix bug with regular font-weight when `Text` component renders as `strong` or `b` element

### DIFF
--- a/components/text/Text.tsx
+++ b/components/text/Text.tsx
@@ -1,6 +1,6 @@
 import { styled } from "../stitches.config";
 
-export const Text = styled("div", {
+const TextComponent = styled("div", {
   color: "$foreground",
   fontFamily: "$system",
   fontWeight: "$normal",
@@ -57,3 +57,31 @@ export const Text = styled("div", {
     },
   },
 });
+
+export interface TextProps extends React.ComponentProps<typeof TextComponent> {
+  as?: React.ElementType;
+  href?: string;
+}
+
+export const Text = ({
+  children,
+  as,
+  href,
+  ...props
+}: TextProps): JSX.Element => {
+  // ignore href prop if "as" element isn't present or not equal to "a" element
+  if (as !== "a" && href !== undefined) {
+    href = undefined;
+  }
+
+  return (
+    <TextComponent
+      css={as === "strong" || as === "b" ? { fontWeight: "$bold" } : undefined}
+      as={as}
+      href={href}
+      {...props}
+    >
+      {children}
+    </TextComponent>
+  );
+};


### PR DESCRIPTION
### Description

This PR fixed the bug when `Text` component renders as `strong` or `b` HTML elements with regular font weight. Now it has `font-weight: $bold` in those cases. The `bold` variable value is defined [in the system config](https://github.com/shdq/spartak-ui/blob/main/components/stitches.config.ts#L166).

```jsx
<Text as="strong">Text in bold</Text>
```

Output HTML:

```html
<strong>Text in bold</strong>
```

---

- [x] I wrote corresponding tests for the features
- [x] I updated the docs with descriptions and code samples

Resolves #52 
