### PR TITLE
fix(text & build): fix text types and circular dependency for build

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { useId, useState, useEffect, useRef } from "react";
 import { styled, checkboxIconSizes } from "../stitches.config";
-import { Text } from "../index";
+import { Text } from "../text/index";
 
 const CheckboxComponent = styled("input", {
   all: "unset",

--- a/components/text/Text.tsx
+++ b/components/text/Text.tsx
@@ -61,6 +61,7 @@ const TextComponent = styled("div", {
 export interface TextProps extends React.ComponentProps<typeof TextComponent> {
   as?: React.ElementType;
   href?: string;
+  target?: React.HTMLAttributeAnchorTarget;
 }
 
 export const Text = ({


### PR DESCRIPTION
**Description**

This PR is a quick fix for:
- Circular dependency in `Checkbox` component imports
- Types for `Text` component (`target` attribute when components used as link `as="a"`)